### PR TITLE
Get rid of the node added to the dom in the willDestroyElement callback

### DIFF
--- a/addon/components/layout/side-hover-panel/component.js
+++ b/addon/components/layout/side-hover-panel/component.js
@@ -5,7 +5,7 @@ let $ = Ember.$;
 export default Ember.Component.extend({
   layout,
   classNames: ['__side-hover-panel'],
-  
+
   // Those are the parameters that you can override
   backdropAction: null,
   side: "right",
@@ -52,6 +52,8 @@ export default Ember.Component.extend({
 
   willDestroyElement() {
     // Re-enable scrolling
+    this.$('.hover-panel').remove();
+    this.$('.panel-backdrop').addClass('hidden');
     if (this.get("disableScrolling") === true) {
       $('body').removeClass('disable-scrolling');
     }


### PR DESCRIPTION
Related to upfluence/facade@0238271

With the new ember glimmer tree the side-hover panel does not go away when we go to an other route

I add an explicit deletion of the node