### PR TITLE
Rework upload-file

### DIFF
--- a/addon/components/file-uploader/component.js
+++ b/addon/components/file-uploader/component.js
@@ -15,11 +15,13 @@ export default Ember.Component.extend({
 
   allowedExtensions: null,
   twoStep: false,
+  extra: {},
 
   // Since this doesn't work well, this is disable by defaut.
   useProgress: false,
 
   // Actions
+  beforeUpload: '',
   didUpload: '',
   onProgress: '',
   didError: '',
@@ -61,7 +63,7 @@ export default Ember.Component.extend({
       });
     }
 
-    if (!errors) {
+    if (Ember.isBlank(errors)) {
       return true;
     }
 
@@ -124,15 +126,22 @@ export default Ember.Component.extend({
           }
         }
 
+        this.set('_file', null);
         this.set('_onUpload', false);
         // dispatch payload from backend
         this.sendAction('didError', payload, errorThrown);
       })
     ;
 
+    let extra = this.get('extra');
+
     if (!Ember.isEmpty(this.get('_file'))) {
+      this.sendAction('beforeUpload', this.get('_file'));
       this.set('_onUpload', true);
-      uploader.upload(this.get('_file'));
+      uploader.upload(this.get('_file'), {
+        ...extra,
+        allowed_extensions: this.get('allowedExtensions'),
+      });
     }
   },
 

--- a/addon/components/file-uploader/component.js
+++ b/addon/components/file-uploader/component.js
@@ -1,15 +1,24 @@
 import Ember from 'ember';
+import EmberUploader from 'ember-uploader';
 import layout from './template';
 
 export default Ember.Component.extend({
   layout,
   classNames: ['file-uploader'],
+  store: Ember.inject.service(),
   session: Ember.inject.service(),
 
   method: 'PUT',
   attribute: 'file',
 
   text: 'Add an file',
+
+  allowedExtensions: null,
+  isValid: false,
+  twoStep: false,
+
+  // Since this doesn't work well, this is disable by defaut.
+  useProgress: false,
 
   // Actions
   didUpload: '',
@@ -18,27 +27,125 @@ export default Ember.Component.extend({
 
   _onUpload: false,
   _percent: 0,
-  _file: {},
+  _file: null,
+
+  url: Ember.computed('model.id', function() {
+    return this.get(
+      'store'
+    ).adapterFor(this.get('model.constructor.modelName')).buildURL(
+      this.get('model.constructor.modelName'),
+      this.get('model.id')
+    );
+  }),
+
+  hasFile: Ember.computed('_file', function () {
+    return !Ember.isEmpty(this.get('_file.name'));
+  }),
+
+  isValid: Ember.computed('hasFile', function () {
+    if (!this.get('hasFile')) {
+      return false;
+    }
+
+    let exts = this.get('_allowedExtensions');
+
+    return Ember.isBlank(exts) ||
+      exts.includes(this._getExtension(this.get('_file.name')));
+  }),
 
   actions: {
-    beforeUpload(file) {
+    clear() {
+      this._clear();
+    },
+    onFile(file) {
       this.set('_file', file);
-      this.set('_onUpload', true);
-      this.set('_percent', 0);
+
+      if (!this.get('twoStep') && this.get('isValid')) {
+        this._upload();
+      }
     },
-    didUpload(e) {
-      this.sendAction('didUpload', e);
-      this.set('_onUpload', false);
-      this.set('_percent', 0);
-    },
-    onProgress(e) {
-      this.set('_percent', e.percent);
-      this.sendAction('onProgress', e);
-    },
-    didError(jqXHR, textStatus, errorThrown) {
-      this.set('_onUpload', false);
-      this.set('error', 'Something happened, please retry.');
-      this.sendAction('didError', jqXHR, textStatus, errorThrown);
+    upload() {
+      this._upload();
     }
-  }
+  },
+
+  _upload() {
+    let uploader = EmberUploader.Uploader.create({
+      url: this.get('url'),
+      method: this.get('method'),
+      paramName: this.get('attribute').underscore(),
+      paramNamespace: this.get('model.constructor.modelName').underscore(),
+      ajaxSettings: {
+        headers: {
+          'Authorization':
+            `Bearer ${this.get('session.data.authenticated.access_token')}`
+        }
+      }
+    });
+
+    uploader
+      .on('didUpload', (e) => {
+        this.sendAction('didUpload', e);
+        this._clear();
+      })
+      .on('progress', (e) => {
+        if (!this.get('useProgress')) {
+          return;
+        }
+
+        this.set('_percent', e.percent);
+        this.sendAction('onProgress', e);
+      })
+      .on('didError', (jqXHR, textStatus, errorThrown) => {
+        let payload = null;
+
+        if (jqXHR.responseText) {
+          try {
+            payload = JSON.parse(jqXHR.responseText);
+          } catch (e) {
+            // silent
+          }
+        }
+
+        this.set('_onUpload', false);
+        // dispatch payload from backend
+        this.sendAction('didError', payload, errorThrown);
+      })
+    ;
+
+    if (!Ember.isEmpty(this.get('_file'))) {
+      this.set('_onUpload', true);
+      uploader.upload(this.get('_file'));
+    }
+  },
+
+  _getExtension(filename) {
+    let extension_matchers = [
+      new RegExp(/^(.+)\.(tar\.([glx]?z|bz2))$/),
+      new RegExp(/^(.+)\.([^\.]+)$/)
+    ];
+
+    for (let i = 0; i < extension_matchers.length; i++) {
+      let match = extension_matchers[i].exec(filename);
+      if (match) {
+        return match[2];
+      }
+    }
+
+    return null;
+  },
+
+  _allowedExtensions: Ember.computed('allowedExtensions', function() {
+    if (Ember.isBlank(this.get('allowedExtensions'))) {
+      return [];
+    }
+
+    return this.get('allowedExtensions').split(',');
+  }),
+
+  _clear() {
+    this.set('_onUpload', false);
+    this.set('_file', null);
+    this.set('_percent', 0);
+  },
 });

--- a/addon/components/file-uploader/template.hbs
+++ b/addon/components/file-uploader/template.hbs
@@ -1,8 +1,6 @@
 {{#if _onUpload}}
   <div class="upload-progress-contianer">
-    <div class="upf-align--center">
-      <i class="fa fa-spinner fa-spin"></i> {{_file.name}}
-    </div>
+    <i class="fa fa-spinner fa-spin"></i> {{_file.name}}
     {{#if useProgress}}
       <div class="upload-progress-bar">
         <div class="upload-progress" style="width: {{_progress}}%"></div>

--- a/addon/components/file-uploader/template.hbs
+++ b/addon/components/file-uploader/template.hbs
@@ -1,27 +1,25 @@
-{{#if error}}
-  <div class="upf-alert upf-alert--error">
-    <span class="upf-alert__text">
-      {{error}}
-    </span>
-  </div>
-{{/if}}
-
 {{#if _onUpload}}
-  <div class="upf-align--center"><i class="fa fa-spinner fa-spin"></i> {{_file.name}}</div>
-  <div class="upload-progress-bar">
-    <div class="upload-progress" style="width: {{_progress}}%"></div>
+  <div class="upload-progress-contianer">
+    <div class="upf-align--center">
+      <i class="fa fa-spinner fa-spin"></i> {{_file.name}}
+    </div>
+    {{#if useProgress}}
+      <div class="upload-progress-bar">
+        <div class="upload-progress" style="width: {{_progress}}%"></div>
+      </div>
+    {{/if}}
   </div>
+{{else if hasFile}}
+  {{_file.name}}
+  <button class="upf-btn upf-btn--orange" disabled={{not isValid}} {{action 'upload'}}>
+    <span>Upload</span>
+  </button>
+  <button class="btn btn-default pointer" {{action 'clear'}}>
+    <i class="fa fa-times"></i>
+  </button>
 {{else}}
   <div class="file-uploader__btn upf-btn upf-btn--orange">
     <span>{{text}}</span>
-    {{input-uploader
-      model=model
-      attribute=attribute
-      method=method
-      beforeUpload=(action 'beforeUpload')
-      didUpload=(action 'didUpload')
-      onProgress=(action 'onProgress')
-      didError=(action 'didError')
-    }}
+    {{input-uploader onFile=(action 'onFile')}}
   </div>
 {{/if}}

--- a/addon/components/input-uploader/component.js
+++ b/addon/components/input-uploader/component.js
@@ -4,57 +4,10 @@ import layout from './template';
 
 export default EmberUploader.FileField.extend({
   layout,
-  store: Ember.inject.service(),
-  session: Ember.inject.service(),
-
-  model: {},
-  method: 'PUT',
-  attribute: 'file',
-
-  // Actions
-  beforeUpload: '',
-  didUpload: '',
-  onProgress: '',
-  didError: '',
-
-  url: Ember.computed('model.id', function() {
-    return this.get(
-      'store'
-    ).adapterFor(this.get('model.constructor.modelName')).buildURL(
-      this.get('model.constructor.modelName'),
-      this.get('model.id')
-    );
-  }),
 
   filesDidChange(files) {
-    let uploader = EmberUploader.Uploader.create({
-      url: this.get('url'),
-      method: this.get('method'),
-      paramName: this.get('attribute').underscore(),
-      paramNamespace: this.get('model.constructor.modelName').underscore(),
-      ajaxSettings: {
-        headers: {
-          'Authorization':
-            `Bearer ${this.get('session.data.authenticated.access_token')}`
-        }
-      }
-    });
-
-    uploader
-      .on('didUpload', (e) => {
-        this.sendAction('didUpload', e);
-      })
-      .on('progress', (e) => {
-        this.sendAction('onProgress', e);
-      })
-      .on('didError', (jqXHR, textStatus, errorThrown) => {
-        this.sendAction('didError', jqXHR, textStatus, errorThrown);
-      })
-    ;
-
     if (!Ember.isEmpty(files)) {
-      this.sendAction('beforeUpload', files[0]);
-      uploader.upload(files[0]);
+      this.sendAction('onFile', files[0]);
     }
   }
 });

--- a/app/styles/components/file-uploader.less
+++ b/app/styles/components/file-uploader.less
@@ -1,5 +1,7 @@
 .file-uploader {
-  width: 250px;
+  .upload-progress-contianer {
+    width: 250px;
+  }
 
   .upload-progress-bar {
     height: 6px;
@@ -7,7 +9,6 @@
   }
 
   .upload-progress {
-    height: 100%;
     background-color: #6eb2ed;
   }
 


### PR DESCRIPTION
A rework to a better use of the file uploader.

This Pr add a twostep option to split the process in two (see screen shot) to avoid the auto upload:
![capture du 2017-07-24 14-40-55](https://user-images.githubusercontent.com/860533/28523822-427a2f5a-707e-11e7-8658-be0767a69fab.png)
![capture du 2017-07-24 14-41-06](https://user-images.githubusercontent.com/860533/28523824-440a463e-707e-11e7-89e1-a8ca7fa86473.png)

`Upload` trigger the upload or the `arrow` return to the default state.

I have add a front extension checker to avoid upload file if the extension is wrong. In this case with or without the `twostep` the upload will be stop and this view is display:
![capture du 2017-07-24 14-51-08](https://user-images.githubusercontent.com/860533/28524311-33ec9502-7080-11e7-8e96-6a5091d2f3d9.png)

Front validation are bubbled with `didValidationError` 

Since progress bar don't work very well, I have add a option to hide it by default.

All of this is for a better errors handler on front and use translations based on errors from backend