### PR TITLE
Get rid of the container div wrapper around the spinner

### DIFF
--- a/addon/templates/components/loading-spinner.hbs
+++ b/addon/templates/components/loading-spinner.hbs
@@ -1,9 +1,7 @@
-<div class="container">
-  <div class="text-center">
-    <div class="spinner">
-      <div class="bounce1"></div>
-      <div class="bounce2"></div>
-      <div class="bounce3"></div>
-    </div>
+<div class="text-center">
+  <div class="spinner">
+    <div class="bounce1"></div>
+    <div class="bounce2"></div>
+    <div class="bounce3"></div>
   </div>
 </div>


### PR DESCRIPTION
@tgallice this is the reason of the horizontal scroll bar in the Facade list page.

Cc. @phndiaye & @tgallice could it break any other compatibility? (i.e. `table-fluid`?)