### PR TITLE
Use Summernote's plugin system for the custom buttons

### DIFF
--- a/addon/components/summer-note/component.js
+++ b/addon/components/summer-note/component.js
@@ -89,11 +89,15 @@ export default SummerNoteComponent.extend({
 
     let _customButtons = {};
     let arrayOfCustomButtons = get(this, 'customButtons');
+
     if (arrayOfCustomButtons) {
-      arrayOfCustomButtons.forEach(function (item, i, /*arr*/) {
-        _customButtons['myButton' + i] = item;
-        _toolbar.push(['myButton' + i, ['myButton' + i]]);
-      });
+      let plugins = arrayOfCustomButtons.reduce((acc, v) => {
+        acc[v.name] = v
+        return acc;
+      }, {});
+
+      $.extend($.summernote.plugins, plugins);
+      _toolbar.push(['insert', Object.keys(plugins)]);
     }
 
     this.$('#summernote').summernote({
@@ -129,6 +133,7 @@ export default SummerNoteComponent.extend({
         }
       }
     });
+
 
     this.$('.dropdown-toggle').dropdown();
 

--- a/addon/components/upf-editor/component.js
+++ b/addon/components/upf-editor/component.js
@@ -8,7 +8,7 @@ export default Component.extend({
   layout,
 
   summernoteContext: null,
-  customButtons: 'video,pdf',
+  customButtons: 'videoUpload,pdfUpload',
   _customButtonsFuncs: [],
 
   hideVideoUploadModal: true,
@@ -19,27 +19,30 @@ export default Component.extend({
     let { ui } = $.summernote;
 
     let uploadBtns = {
-      video: (context) => {
-
-        return ui.button({
-          contents: '<i class="fa fa-video-camera"/></i>',
-          tooltip: 'Insert a video',
-          click() {
-            self.set('summernoteContext', context);
-            self.send('toggleVideoUpload');
-          }
-        }).render();
+      videoUpload: (context) => {
+        context.memo('button.videoUpload', function () {
+           return ui.button({
+            contents: '<i class="fa fa-video-camera"/></i>',
+            tooltip: 'Insert Video',
+            click: () => {
+              self.set('summernoteContext', context);
+              self.send('toggleVideoUpload');
+            }
+          }).render();
+        });
       },
 
-      pdf: (context) => {
-        return ui.button({
-          contents: '<i class="fa fa-file-pdf-o"></i>',
-          tooltip: 'Insert a PDF file',
-          click() {
-            self.set('summernoteContext', context);
-            self.send('togglePDFUpload');
-          }
-        }).render();
+      pdfUpload: (context) => {
+        context.memo('button.pdfUpload', function () {
+          return ui.button({
+            contents: '<i class="fa fa-file-pdf-o"></i>',
+            tooltip: 'Insert a PDF file',
+            click() {
+              self.set('summernoteContext', context);
+              self.send('togglePDFUpload');
+            }
+          }).render();
+        });
       }
     };
 

--- a/addon/components/upf-editor/component.js
+++ b/addon/components/upf-editor/component.js
@@ -20,8 +20,8 @@ export default Component.extend({
 
     let uploadBtns = {
       videoUpload: (context) => {
-        context.memo('button.videoUpload', function () {
-           return ui.button({
+        context.memo('button.videoUpload', function() {
+          return ui.button({
             contents: '<i class="fa fa-video-camera"/></i>',
             tooltip: 'Insert Video',
             click: () => {
@@ -33,7 +33,7 @@ export default Component.extend({
       },
 
       pdfUpload: (context) => {
-        context.memo('button.pdfUpload', function () {
+        context.memo('button.pdfUpload', function() {
           return ui.button({
             contents: '<i class="fa fa-file-pdf-o"></i>',
             tooltip: 'Insert a PDF file',


### PR DESCRIPTION
Use Summernote's plugin system for our custom buttons instead of just pushing them in the toolbar. This fixes the issue with custom buttons stacking up after navigation because they were not properly destroyed with the Summernote Instance.