### PR TITLE
Remove the type and let guess it

### DIFF
--- a/addon/components/publishr/draft-display/medias/template.hbs
+++ b/addon/components/publishr/draft-display/medias/template.hbs
@@ -18,7 +18,7 @@
       {{else}}
         <div class="draft-media-card__video">
           <video controls>
-            <source src={{media.url}} type={{media.contentType}}>
+            <source src={{media.url}}>
           </video>
         </div>
       {{/if}}


### PR DESCRIPTION
This issue comme from jhonayce, video from draft won't work correctly here is an exemple: https://software.upfluence.co/client/campaigns/mbp-christmas-pl-771/drafts/mbp-christmas-pl-christophermakowski-98352

I remove the type with is `application/octet-stream` for the exemple and this lead to the issue IMO. Without the type, the bowser guess with the file. 

@phndiaye can you check on this ? Do you see something wrong ?