### PR TITLE
universal-selection: allow label on the power-select

### DIFF
--- a/addon/components/universal-export/external/template.hbs
+++ b/addon/components/universal-export/external/template.hbs
@@ -1,6 +1,6 @@
-<div class="modal-body">
+<div class="modal-body upf-align--center">
   {{#input-wrapper}}
-    <label>
+    <label class="padding-xx-sm">
       Export a selection of influencers to a list, emailing, campaign or stream
     </label>
 

--- a/addon/components/universal-selection/component.js
+++ b/addon/components/universal-selection/component.js
@@ -10,6 +10,8 @@ import layout from './template';
 export default Component.extend({
   layout,
 
+  classNames: ['universal-selection'],
+
   exports: service(),
   toast: service(),
 
@@ -18,6 +20,7 @@ export default Component.extend({
   createItemComponent: null,
   items: null,
   current: null,
+  label: null,
   placeholder: 'Import influencers from...',
 
   _performSearch(resolve) {

--- a/addon/components/universal-selection/template.hbs
+++ b/addon/components/universal-selection/template.hbs
@@ -1,13 +1,15 @@
-<div class="padding-top-sm padding-bottom-sm universal-selection">
-  {{#item-chooser
-    groupComponent="universal-selection/group"
-    selectedItemComponent="universal-selection/selected"
-    onopen=(action "checkOptions")
-    multiple=multiple items=items selection=current 
-    optionValuePath="content.identifier"
-    placeholder=placeholder allowClear=true search=(action "searchEntities")
-    canCreate=canCreate createItemComponent=createItemComponent
-    didCreate=null as |opt|}}
-    {{universal-selection/option item=opt.option}}
-  {{/item-chooser}}
-</div>
+{{#if label}}
+  <label>{{label}}</label>
+{{/if}}
+
+{{#item-chooser
+  groupComponent="universal-selection/group"
+  selectedItemComponent="universal-selection/selected"
+  onopen=(action "checkOptions")
+  multiple=multiple items=items selection=current
+  optionValuePath="content.identifier"
+  placeholder=placeholder allowClear=true search=(action "searchEntities")
+  canCreate=canCreate createItemComponent=createItemComponent
+  didCreate=null as |opt|}}
+  {{universal-selection/option item=opt.option}}
+{{/item-chooser}}


### PR DESCRIPTION
@leanminmachine added this for the universal selection, it's optional but needed in publishr/analytics. for the import can you help do the update to pass the labels ? it's for a better understanding of what the selection does :) 