### PR TITLE
reload selected users with entity change, for notes

### DIFF
--- a/addon/components/ownership-selection-modal.js
+++ b/addon/components/ownership-selection-modal.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { computed, defineProperty } from '@ember/object';
+import { computed, defineProperty, observer } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 
 export default Component.extend({
   classNames: ['ownership-selection'],
@@ -24,6 +25,12 @@ export default Component.extend({
     people: true,
     groups: true
   },
+
+  _resetWindow: observer('entity.id', function() {
+    if (isEmpty(this.selectedUsers)) {
+      this.set('currentWindow', 'groups')
+    }
+  }),
 
   init() {
     this._super();

--- a/addon/components/ownership-selection-modal.js
+++ b/addon/components/ownership-selection-modal.js
@@ -26,7 +26,7 @@ export default Component.extend({
     groups: true
   },
 
-  _resetWindow: observer('selectedUsers', function() {
+  _resetWindow: observer('entity.id', function() {
     if (isEmpty(this.selectedUsers)) {
       this.set('currentWindow', 'groups')
     }

--- a/addon/components/ownership-selection-modal.js
+++ b/addon/components/ownership-selection-modal.js
@@ -26,7 +26,7 @@ export default Component.extend({
     groups: true
   },
 
-  _resetWindow: observer('entity.id', function() {
+  _resetWindow: observer('selectedUsers', function() {
     if (isEmpty(this.selectedUsers)) {
       this.set('currentWindow', 'groups')
     }

--- a/addon/components/ownership-selection-modal.js
+++ b/addon/components/ownership-selection-modal.js
@@ -27,7 +27,7 @@ export default Component.extend({
   },
 
   _resetWindow: observer('model.id', function() {
-    this.set('currentWindow', this.model.ownedBy.startsWith('composite:') ? 'people' : 'groups')
+    this.set('currentWindow', this.model.ownedBy.startsWith('composite:') ? 'people' : 'groups');
   }),
 
   init() {

--- a/addon/components/ownership-selection-modal.js
+++ b/addon/components/ownership-selection-modal.js
@@ -27,7 +27,8 @@ export default Component.extend({
   },
 
   _resetWindow: observer('model.id', function() {
-    this.set('currentWindow', this.model.ownedBy.startsWith('composite:') ? 'people' : 'groups');
+    const isComposite = this.model.ownedBy.startsWith('composite:');
+    this.set('currentWindow', isComposite ? 'people' : 'groups');
   }),
 
   init() {

--- a/addon/components/ownership-selection-modal.js
+++ b/addon/components/ownership-selection-modal.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed, defineProperty, observer } from '@ember/object';
-import { isEmpty } from '@ember/utils';
 
 export default Component.extend({
   classNames: ['ownership-selection'],
@@ -70,7 +69,8 @@ export default Component.extend({
         this.get('modelType'),
         this.get('model.id'),
         newOwnership
-      ).then(() => {
+      ).then((entity) => {
+        this.model.set('ownedBy', entity[this.modelType].owned_by);
         this.send('performCloseModal');
       });
     }

--- a/addon/components/ownership-selection-modal.js
+++ b/addon/components/ownership-selection-modal.js
@@ -26,10 +26,8 @@ export default Component.extend({
     groups: true
   },
 
-  _resetWindow: observer('entity.id', function() {
-    if (isEmpty(this.selectedUsers)) {
-      this.set('currentWindow', 'groups')
-    }
+  _resetWindow: observer('model.id', function() {
+    this.set('currentWindow', this.model.ownedBy.startsWith('composite:') ? 'people' : 'groups')
   }),
 
   init() {

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -63,7 +63,7 @@ export default Component.extend({
     }))
   }),
 
-  _reloadSelected: observer('entity', function() {
+  _reloadSelected: observer('entity.id', function() {
     this.get('currentUser').fetchOwnerships().then((ownerships) => {
       let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
       let selectedUsers;

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -35,13 +35,7 @@ export default Component.extend({
         this.get('currentUser').fetchOwnerships().then((ownerships) => {
           if (!this.entity.ownedBy.startsWith('composite:')) return;
 
-          let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
-          this.set(
-            'selectedUsers',
-            this.availableUsers.filter((x) => {
-              return currentOwnership.userIds.includes(x.id);
-            })
-          );
+          this._fetchSelectedUsers(ownerships);
         });
       });
     });
@@ -65,20 +59,24 @@ export default Component.extend({
 
   _reloadSelected: observer('entity.id', function() {
     this.get('currentUser').fetchOwnerships().then((ownerships) => {
-      let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
-      let selectedUsers;
-
-      if (currentOwnership.userIds) {
-        selectedUsers = this.availableUsers.filter((x) => {
-          return currentOwnership.userIds.includes(x.id);
-        });
-      } else {
-        selectedUsers = [];
-      }
-      
-      this.set('selectedUsers', selectedUsers);
+      this._fetchSelectedUsers(ownerships);
     });
   }),
+
+  _fetchSelectedUsers(ownerships) {
+    let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
+    let selectedUsers;
+
+    if (currentOwnership.userIds) {
+      selectedUsers = this.availableUsers.filter((x) => {
+        return currentOwnership.userIds.includes(x.id);
+      });
+    } else {
+      selectedUsers = [];
+    }
+    
+    this.set('selectedUsers', selectedUsers);
+  },
 
   actions: {
     searchEntities(text) {

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -63,6 +63,23 @@ export default Component.extend({
     }))
   }),
 
+  _reloadSelected: observer('entity', function() {
+    this.get('currentUser').fetchOwnerships().then((ownerships) => {
+      let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
+      let selectedUsers;
+
+      if (currentOwnership.userIds) {
+        selectedUsers = this.availableUsers.filter((x) => {
+          return currentOwnership.userIds.includes(x.id);
+        });
+      } else {
+        selectedUsers = [];
+      }
+      
+      this.set('selectedUsers', selectedUsers);
+    });
+  }),
+
   actions: {
     searchEntities(text) {
       this.set('searchTerm', text);

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -77,6 +77,10 @@ export default Component.extend({
       }
       
       this.set('selectedUsers', selectedUsers);
+
+      if (isEmpty(this.selectedUsers)) {
+        this.set('currentWindow', 'groups')
+      }
     });
   }),
 

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -35,7 +35,7 @@ export default Component.extend({
         this.get('currentUser').fetchOwnerships().then((ownerships) => {
           if (!this.entity.ownedBy.startsWith('composite:')) return;
 
-          this._fetchSelectedUsers(ownerships);
+          this._setSelectedUsers(ownerships);
         });
       });
     });
@@ -59,7 +59,7 @@ export default Component.extend({
 
   _reloadSelected: observer('entity.id', function() {
     this.get('currentUser').fetchOwnerships().then((ownerships) => {
-      this._fetchSelectedUsers(ownerships);
+      this._setSelectedUsers(ownerships);
     });
   }),
 

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -33,8 +33,6 @@ export default Component.extend({
         this.set('items', coworkers);
 
         this.get('currentUser').fetchOwnerships().then((ownerships) => {
-          if (!this.entity.ownedBy.startsWith('composite:')) return;
-
           this._setSelectedUsers(ownerships);
         });
       });
@@ -64,6 +62,7 @@ export default Component.extend({
   }),
 
   _setSelectedUsers(ownerships) {
+    if (!this.entity.ownedBy.startsWith('composite:')) return;
     let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
     let selectedUsers;
 

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -63,7 +63,7 @@ export default Component.extend({
     });
   }),
 
-  _fetchSelectedUsers(ownerships) {
+  _setSelectedUsers(ownerships) {
     let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
     let selectedUsers;
 

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -77,10 +77,6 @@ export default Component.extend({
       }
       
       this.set('selectedUsers', selectedUsers);
-
-      if (isEmpty(this.selectedUsers)) {
-        this.set('currentWindow', 'groups')
-      }
     });
   }),
 

--- a/addon/components/ownership-selection-modal/people/component.js
+++ b/addon/components/ownership-selection-modal/people/component.js
@@ -64,14 +64,12 @@ export default Component.extend({
   _setSelectedUsers(ownerships) {
     if (!this.entity.ownedBy.startsWith('composite:')) return;
     let currentOwnership = ownerships.findBy('id', this.entity.ownedBy);
-    let selectedUsers;
+    let selectedUsers = [];
 
     if (currentOwnership.userIds) {
       selectedUsers = this.availableUsers.filter((x) => {
         return currentOwnership.userIds.includes(x.id);
       });
-    } else {
-      selectedUsers = [];
     }
     
     this.set('selectedUsers', selectedUsers);

--- a/app/templates/components/ownership-selection-modal.hbs
+++ b/app/templates/components/ownership-selection-modal.hbs
@@ -21,8 +21,7 @@
   </ul>
 
   {{#if peopleSelected}}
-    {{ownership-selection-modal/people entity=model 
-      selectedUsers=selectedUsers
+    {{ownership-selection-modal/people entity=model
       saveOwnership=(action "saveOwnership")}}
   {{else}}
     {{ownership-selection-modal/groups entity=model 

--- a/app/templates/components/ownership-selection-modal.hbs
+++ b/app/templates/components/ownership-selection-modal.hbs
@@ -23,8 +23,7 @@
   {{#if peopleSelected}}
     {{ownership-selection-modal/people entity=model 
       selectedUsers=selectedUsers
-      saveOwnership=(action "saveOwnership") 
-      currentWindow=currentWindow}}
+      saveOwnership=(action "saveOwnership")}}
   {{else}}
     {{ownership-selection-modal/groups entity=model 
       saveOwnership=(action "saveOwnership")}}

--- a/app/templates/components/ownership-selection-modal.hbs
+++ b/app/templates/components/ownership-selection-modal.hbs
@@ -21,11 +21,12 @@
   </ul>
 
   {{#if peopleSelected}}
-    {{ownership-selection-modal/people
-      entity=model selectedUsers=selectedUsers
-      saveOwnership=(action "saveOwnership")}}
+    {{ownership-selection-modal/people entity=model 
+      selectedUsers=selectedUsers
+      saveOwnership=(action "saveOwnership") 
+      currentWindow=currentWindow}}
   {{else}}
-    {{ownership-selection-modal/groups
-      entity=model saveOwnership=(action "saveOwnership")}}
+    {{ownership-selection-modal/groups entity=model 
+      saveOwnership=(action "saveOwnership")}}
   {{/if}}
 {{/modal-view}}


### PR DESCRIPTION
when a different note is selected after a note was selected, the different note should not have the preselected ownership entity from the original note shown.