### PR TITLE
Fix active state on facade, publishr-client, analytics

### DIFF
--- a/addon/components/layout/left-menu/component.js
+++ b/addon/components/layout/left-menu/component.js
@@ -77,11 +77,22 @@ export default Component.extend({
   }),
 
   listURL: computed('facadeURL', function() {
-    if (this.get('facadeURL')) {
-      return `${this.get('facadeURL')}lists`;
-    }
+    // if (this.get('facadeURL')) {
+    //   return `${this.get('facadeURL')}lists`;
+    // }
 
-    return 'lists';
+    // return 'lists';
+
+    let url = getOwner(this).resolveRegistration(
+      'config:environment'
+    ).facadeURL;
+
+    let module = getOwner(this).resolveRegistration(
+      'config:environment'
+    ).modulePrefix;
+
+    // Since application is a valid route this will active the icon
+    return module === 'facade-web' ? 'application' : url;
   }),
 
   inboxURL: computed(function() {

--- a/addon/components/layout/left-menu/component.js
+++ b/addon/components/layout/left-menu/component.js
@@ -77,15 +77,11 @@ export default Component.extend({
   }),
 
   listURL: computed('facadeURL', function() {
-    let url = getOwner(this).resolveRegistration(
-      'config:environment'
-    ).facadeURL;
-
     let module = getOwner(this).resolveRegistration(
       'config:environment'
     ).modulePrefix;
 
-    return module === 'facade-web' ? 'application' : url;
+    return module === 'facade-web' ? 'application' : this.facadeURL;
   }),
 
   inboxURL: computed(function() {

--- a/addon/components/layout/left-menu/component.js
+++ b/addon/components/layout/left-menu/component.js
@@ -69,20 +69,14 @@ export default Component.extend({
   }),
 
   streamsURL: computed('analyticsURL', function() {
-    if (this.get('analyticsURL')) {
-      return `${this.get('analyticsURL')}streams`;
-    }
+    let module = getOwner(this).resolveRegistration(
+      'config:environment'
+    ).modulePrefix;
 
-    return 'streams';
+    return module === 'analytics-web' ? 'application' : this.analyticsURL;
   }),
 
   listURL: computed('facadeURL', function() {
-    // if (this.get('facadeURL')) {
-    //   return `${this.get('facadeURL')}lists`;
-    // }
-
-    // return 'lists';
-
     let url = getOwner(this).resolveRegistration(
       'config:environment'
     ).facadeURL;
@@ -91,7 +85,6 @@ export default Component.extend({
       'config:environment'
     ).modulePrefix;
 
-    // Since application is a valid route this will active the icon
     return module === 'facade-web' ? 'application' : url;
   }),
 
@@ -133,10 +126,16 @@ export default Component.extend({
   publishrClientURL: computed('_publishrClientURL', function() {
     let baseURL = getOwner(this).resolveRegistration(
       'config:environment'
-    ).publishrClientURL || '';
+    ).publishrClientURL || '';
+
+    let module = getOwner(this).resolveRegistration(
+      'config:environment'
+    ).modulePrefix;
 
     let suffix = baseURL.endsWith('/') ? 'campaigns' : '/campaigns';
-    return baseURL + suffix;
+    let fullURL = baseURL + suffix;
+
+    return module === 'publishr-client-web' ? 'application' : fullURL;
   }),
 
   actions: {


### PR DESCRIPTION
On the side bar, their icons do not have the 'active' state when you select them

<img width="1439" alt="Screen Shot 2019-11-07 at 3 49 14 PM" src="https://user-images.githubusercontent.com/16240321/68426526-527e5080-0176-11ea-9e35-e7a31372e4a1.png">
<img width="1439" alt="Screen Shot 2019-11-07 at 3 49 02 PM" src="https://user-images.githubusercontent.com/16240321/68426527-527e5080-0176-11ea-9183-025a7695df49.png">
<img width="1436" alt="Screen Shot 2019-11-07 at 3 48 47 PM" src="https://user-images.githubusercontent.com/16240321/68426528-527e5080-0176-11ea-92e4-0e2c5e30befa.png">
