### PR TITLE
Add validation modal to universal export

### DIFF
--- a/addon/components/influencer-network-modal/component.js
+++ b/addon/components/influencer-network-modal/component.js
@@ -1,0 +1,30 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import layout from './template';
+
+const INFLUENCER_NETWORK_MODAL_COOKIE = "upf_disable_influencer_modal";
+
+export default Component.extend({
+  layout,
+
+  hasDisabledInfluencerNetworkModal: computed(function() {
+    const cookieValue = document.cookie
+      .split('; ')
+      .find(row => row.startsWith(INFLUENCER_NETWORK_MODAL_COOKIE))
+      ?.split('=')[1];
+
+    return cookieValue;
+  }),
+
+  actions: {
+    dontShowInfluencerNetworkModal(disableModal) {
+      this.toggleProperty('hasDisabledInfluencerNetworkModal');
+
+      document.cookie = `${INFLUENCER_NETWORK_MODAL_COOKIE}=${disableModal ? true : ''}`;
+    },
+
+    closeInfluencerNetworkModal() {
+      this.toggleProperty('hideInfluencerNetwork')
+    }
+  }
+});

--- a/addon/components/influencer-network-modal/component.js
+++ b/addon/components/influencer-network-modal/component.js
@@ -24,7 +24,7 @@ export default Component.extend({
     },
 
     closeInfluencerNetworkModal() {
-      this.toggleProperty('hideInfluencerNetwork')
+      this.toggleProperty('hideInfluencerNetworkModal')
     }
   }
 });

--- a/addon/components/influencer-network-modal/template.hbs
+++ b/addon/components/influencer-network-modal/template.hbs
@@ -1,4 +1,4 @@
-{{#modal-view hidden=hideInfluencerNetwork closeAction=closeInfluencerNetworkModal centered=true
+{{#modal-view hidden=hideInfluencerNetworkModal closeAction=closeInfluencerNetworkModal centered=true
   borderlessHeader=true title=(t "influencer_network.modal.title") container="body"}}
   <div class="modal-body text-center">
     <p class="text-size-7">

--- a/addon/components/influencer-network-modal/template.hbs
+++ b/addon/components/influencer-network-modal/template.hbs
@@ -1,0 +1,30 @@
+{{#modal-view hidden=hideInfluencerNetwork closeAction=closeInfluencerNetworkModal centered=true
+  borderlessHeader=true title=(t "influencer_network.modal.title") container="body"}}
+  <div class="modal-body text-center">
+    <p class="text-size-7">
+      <b>{{t "influencer_network.modal.title2"}}</b>
+    </p>
+    <p class="text-size-5 text-color-default-lighter padding-left-md padding-right-md">
+      {{t "influencer_network.modal.subtitle"}}
+    </p>
+
+    <div>
+      <a {{action "closeInfluencerNetworkModal"}} target="_blank" class="upf-btn upf-btn--default margin-top-x-sm margin-bottom-x-sm margin-right-xx-sm">
+        {{t "influencer_network.modal.skip"}}
+      </a>
+      <a href="http://help.upfluence.co" target="_blank" class="upf-btn upf-btn--primary margin-top-x-sm margin-bottom-x-sm">
+        {{t "influencer_network.modal.learn_more"}}
+      </a>
+    </div>
+
+    <div>
+    {{#input-wrapper class="influencer-network-checkbox"}}
+      {{#upf-checkbox value=hasDisabledInfluencerNetworkModal hasLabel=true onValueChange=(action "dontShowInfluencerNetworkModal")}}
+        <span>
+          {{t "influencer_network.modal.dont_show"}}
+        </span>
+      {{/upf-checkbox}}
+    {{/input-wrapper}}
+    </div>
+  </div>
+{{/modal-view}}

--- a/addon/components/universal-export/component.js
+++ b/addon/components/universal-export/component.js
@@ -6,6 +6,8 @@ import layout from './template';
 
 const EXTERNAL_EXPORTS = ['list', 'mailing', 'campaign', 'stream'];
 
+const INFLUENCER_NETWORK_MODAL_COOKIE = "upf_disable_influencer_modal";
+
 export default Component.extend({
   layout,
 
@@ -29,6 +31,16 @@ export default Component.extend({
 
   currentWindow: 'file',
   filters: [],
+  hideInfluencerNetwork: false,
+
+  hasDisabledInfluencerNetworkModal: computed(function() {
+    const cookieValue = document.cookie
+      .split('; ')
+      .find(row => row.startsWith(INFLUENCER_NETWORK_MODAL_COOKIE))
+      .split('=')[1];
+
+    return cookieValue;
+  }),
 
   init() {
     this._super();
@@ -103,8 +115,23 @@ export default Component.extend({
   },
 
   actions: {
+    dontShowInfluencerNetworkModal(disableModal) {
+      this.toggleProperty('hasDisabledInfluencerNetworkModal');
+
+      if(disableModal) {
+        document.cookie = `${INFLUENCER_NETWORK_MODAL_COOKIE}=true`;
+        return;
+      }
+
+      document.cookie = `${INFLUENCER_NETWORK_MODAL_COOKIE}=`;
+    },
+
     setCurrent(tab) {
       this.set('currentWindow', tab);
+    },
+
+    closeInfluencerNetworkModal() {
+      this.toggleProperty('hideInfluencerNetwork')
     },
 
     performExport(to, defer) {
@@ -131,6 +158,7 @@ export default Component.extend({
             'Export completed',
             this._toastConfig
           );
+          this.toggleProperty('hideInfluencerNetwork')
         }
 
         this._exported();

--- a/addon/components/universal-export/component.js
+++ b/addon/components/universal-export/component.js
@@ -140,7 +140,7 @@ export default Component.extend({
             this._toastConfig
           );
 
-          if(hasEmailRevealScope) {
+          if(this.hasEmailRevealScope) {
             this.toggleProperty('hideInfluencerNetworkModal');
           }
         }

--- a/addon/components/universal-export/component.js
+++ b/addon/components/universal-export/component.js
@@ -6,8 +6,6 @@ import layout from './template';
 
 const EXTERNAL_EXPORTS = ['list', 'mailing', 'campaign', 'stream'];
 
-const INFLUENCER_NETWORK_MODAL_COOKIE = "upf_disable_influencer_modal";
-
 export default Component.extend({
   layout,
 
@@ -33,15 +31,6 @@ export default Component.extend({
   filters: [],
   hideInfluencerNetwork: false,
 
-  hasDisabledInfluencerNetworkModal: computed(function() {
-    const cookieValue = document.cookie
-      .split('; ')
-      .find(row => row.startsWith(INFLUENCER_NETWORK_MODAL_COOKIE))
-      .split('=')[1];
-
-    return cookieValue;
-  }),
-
   init() {
     this._super();
 
@@ -59,7 +48,6 @@ export default Component.extend({
 
       this.set('currentWindow', this.tabs.external ? 'external' : 'file');
     });
-
 
     ['file', 'external'].forEach((e) => {
       defineProperty(
@@ -115,18 +103,8 @@ export default Component.extend({
   },
 
   actions: {
-    dontShowInfluencerNetworkModal(disableModal) {
-      this.toggleProperty('hasDisabledInfluencerNetworkModal');
-
-      document.cookie = `${INFLUENCER_NETWORK_MODAL_COOKIE}=${disableModal ? true : ''}`;
-    },
-
     setCurrent(tab) {
       this.set('currentWindow', tab);
-    },
-
-    closeInfluencerNetworkModal() {
-      this.toggleProperty('hideInfluencerNetwork')
     },
 
     performExport(to, defer) {

--- a/addon/components/universal-export/component.js
+++ b/addon/components/universal-export/component.js
@@ -118,12 +118,7 @@ export default Component.extend({
     dontShowInfluencerNetworkModal(disableModal) {
       this.toggleProperty('hasDisabledInfluencerNetworkModal');
 
-      if(disableModal) {
-        document.cookie = `${INFLUENCER_NETWORK_MODAL_COOKIE}=true`;
-        return;
-      }
-
-      document.cookie = `${INFLUENCER_NETWORK_MODAL_COOKIE}=`;
+      document.cookie = `${INFLUENCER_NETWORK_MODAL_COOKIE}=${disableModal ? true : ''}`;
     },
 
     setCurrent(tab) {

--- a/addon/components/universal-export/component.js
+++ b/addon/components/universal-export/component.js
@@ -29,10 +29,18 @@ export default Component.extend({
 
   currentWindow: 'file',
   filters: [],
-  hideInfluencerNetwork: true,
+  hideInfluencerNetworkModal: true,
+  hasEmailRevealScope: false,
 
   init() {
     this._super();
+
+    this.get('currentUser').fetch().then((response) => {
+      this.set(
+        'hasEmailRevealScope',
+        response.user.granted_scopes.includes('reveal_email')
+      );
+    });
 
     this.get('exports').getAvailableExports().then((availableExports) => {
       this.set(
@@ -131,7 +139,10 @@ export default Component.extend({
             'Export completed',
             this._toastConfig
           );
-          this.toggleProperty('hideInfluencerNetwork')
+
+          if(hasEmailRevealScope) {
+            this.toggleProperty('hideInfluencerNetworkModal');
+          }
         }
 
         this._exported();

--- a/addon/components/universal-export/component.js
+++ b/addon/components/universal-export/component.js
@@ -29,7 +29,7 @@ export default Component.extend({
 
   currentWindow: 'file',
   filters: [],
-  hideInfluencerNetwork: false,
+  hideInfluencerNetwork: true,
 
   init() {
     this._super();

--- a/addon/components/universal-export/external/template.hbs
+++ b/addon/components/universal-export/external/template.hbs
@@ -27,5 +27,7 @@
     {{#if current}}
       {{t (concat "export_influencers.export." current.type)}}
     {{/if}}
+    <i class="fa fa-info-circle" title={{t "export_influencers.export.tooltip"}}
+       data-toggle="tooltip">
   {{/loading-button}}
 </div>

--- a/addon/components/universal-export/template.hbs
+++ b/addon/components/universal-export/template.hbs
@@ -26,4 +26,4 @@
   {{/if}}
 {{/modal-view}}
 
-{{influencer-network-modal hideInfluencerNetwork=hideInfluencerNetwork}}
+{{influencer-network-modal hideInfluencerNetworkModal=hideInfluencerNetworkModal}}

--- a/addon/components/universal-export/template.hbs
+++ b/addon/components/universal-export/template.hbs
@@ -25,3 +25,33 @@
       performExport=(action "performExport")}}
   {{/if}}
 {{/modal-view}}
+
+
+{{#modal-view hidden=hideInfluencerNetwork closeAction=closeInfluencerNetworkModal centered=true
+  borderlessHeader=true title="Influencer Network" container="body"}}
+  <div class="modal-body text-center">
+    <p class="text-size-7">
+      <b>Influencer has been added to your network</b>
+    </p>
+    <p class="text-size-5 text-color-default-lighter padding-left-md padding-right-md">
+      By adding this influencer to your list, it was automatically added to your Influencers Network. You can access and edit your network in your IRM.
+    </p>
+
+    <div>
+      <a {{action "closeInfluencerNetworkModal"}} target="_blank" class="upf-btn upf-btn--default margin-top-x-sm margin-bottom-x-sm margin-right-xx-sm">
+        Skip
+      </a>
+      <a href="http://help.upfluence.co" target="_blank" class="upf-btn upf-btn--primary margin-top-x-sm margin-bottom-x-sm">
+        Learn More
+      </a>
+    </div>
+
+    <div>
+    {{#input-wrapper class="influencer-network-checkbox"}}
+      {{#upf-checkbox value=hasDisabledInfluencerNetworkModal hasLabel=true onValueChange=(action "dontShowInfluencerNetworkModal")}}
+        <span>Don't show me this again</span>
+      {{/upf-checkbox}}
+    {{/input-wrapper}}
+    </div>
+  </div>
+{{/modal-view}}

--- a/addon/components/universal-export/template.hbs
+++ b/addon/components/universal-export/template.hbs
@@ -26,32 +26,4 @@
   {{/if}}
 {{/modal-view}}
 
-
-{{#modal-view hidden=hideInfluencerNetwork closeAction=closeInfluencerNetworkModal centered=true
-  borderlessHeader=true title="Influencer Network" container="body"}}
-  <div class="modal-body text-center">
-    <p class="text-size-7">
-      <b>Influencer has been added to your network</b>
-    </p>
-    <p class="text-size-5 text-color-default-lighter padding-left-md padding-right-md">
-      By adding this influencer to your list, it was automatically added to your Influencers Network. You can access and edit your network in your IRM.
-    </p>
-
-    <div>
-      <a {{action "closeInfluencerNetworkModal"}} target="_blank" class="upf-btn upf-btn--default margin-top-x-sm margin-bottom-x-sm margin-right-xx-sm">
-        Skip
-      </a>
-      <a href="http://help.upfluence.co" target="_blank" class="upf-btn upf-btn--primary margin-top-x-sm margin-bottom-x-sm">
-        Learn More
-      </a>
-    </div>
-
-    <div>
-    {{#input-wrapper class="influencer-network-checkbox"}}
-      {{#upf-checkbox value=hasDisabledInfluencerNetworkModal hasLabel=true onValueChange=(action "dontShowInfluencerNetworkModal")}}
-        <span>Don't show me this again</span>
-      {{/upf-checkbox}}
-    {{/input-wrapper}}
-    </div>
-  </div>
-{{/modal-view}}
+{{influencer-network-modal hideInfluencerNetwork=hideInfluencerNetwork}}

--- a/app/components/influencer-network-modal/component.js
+++ b/app/components/influencer-network-modal/component.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/ember-upf-utils/components/influencer-network-modal/component';

--- a/app/styles/bootstrap/modal.less
+++ b/app/styles/bootstrap/modal.less
@@ -4,7 +4,6 @@
     margin: 0 auto !important;
 }
 
-
 .influencer-network-checkbox {
   width: 220px;
   margin: auto;

--- a/app/styles/bootstrap/modal.less
+++ b/app/styles/bootstrap/modal.less
@@ -3,3 +3,22 @@
     top: 46% !important;
     margin: 0 auto !important;
 }
+
+
+.influencer-network-checkbox {
+  width: 220px;
+  margin: auto;
+
+  .upf-checkbox__label {
+    position: unset;
+    margin-left: @spacing-xxx-sm;
+  }
+
+  .upf-checkbox--has-label {
+    left: unset;
+  }
+
+  .upf-checkbox__input:checked + .upf-checkbox__fake-checkbox:after {
+    left: 31px;
+  }
+}

--- a/tests/integration/components/influencer-network-modal/component-test.js
+++ b/tests/integration/components/influencer-network-modal/component-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | influencer-network-modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{influencer-network-modal}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#influencer-network-modal}}
+        template block text
+      {{/influencer-network-modal}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -10,6 +10,7 @@ export_influencers:
     cta: Move to
     list: list
     stream: stream
+    tooltip: The influencers you are going to move will be automatically added to your Influencer Network.
     campaign: campaign
     mailing: mailing
     discount_plan: discount offer

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -26,6 +26,16 @@ export_influencers:
     campaign: Campaign
     mailing: Mailing
     discount_plan: Discount Offer
+influencer_network:
+  modal:
+    title: Influencer Network
+    title2: Influencer has been added to your network
+    subtitle: |
+                By adding this influencer to your list, it was automatically added to your Influencers Network.
+                You can access and edit your network in your IRM.
+    skip: Skip
+    learn_more: Learn More
+    dont_show: Don't show me this again
 ownership_selection:
   placeholder: Share with
   tabs:


### PR DESCRIPTION
## What does this PR do ?
Adds a validation modal to inform user that selected influencers have been added to their influencer network.
https://github.com/upfluence/backlog/issues/27
## What are the observable changes?
A modal with more information about influencer network will now be displayed after a user exports a list of influencers

### Good PR checklist  
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [x] Properly labeled