### PR TITLE
CountryChooser: fix _selection not being assigned on initial loa even w/ countryCode(s) not being empty

### DIFF
--- a/addon/components/country-chooser.js
+++ b/addon/components/country-chooser.js
@@ -29,7 +29,7 @@ export default class CountryChooserComponent extends Component {
     return this.codes.findBy('id', this.countryCode);
   }
 
-  // This is because having a getter forces us to have a setter when wwriting a
+  // This is because having a getter forces us to have a setter when writing a
   // in an attribute. The value change is still performed.
   set _selection(v) {}
 

--- a/addon/components/country-chooser.js
+++ b/addon/components/country-chooser.js
@@ -14,12 +14,24 @@ export default class CountryChooserComponent extends Component {
   get size() { return this.args.size || null; }
 
   get countryCode() {
-    return (this._selection || {}).id;
+    return this.args.countryCode || null;
   }
 
   get countryCodes() {
-    return (this._selection || []).map((x) => x.id);
+    return (this.args.countryCodes || []);
   }
+
+  get _selection() {
+    if (this.multiple) {
+      return this.countryCodes.map((id) => this.codes.findBy('id', id));
+    }
+
+    return this.codes.findBy('id', this.countryCode);
+  }
+
+  // This is because having a getter forces us to have a setter when wwriting a
+  // in an attribute. The value change is still performed.
+  set _selection(v) {}
 
   get onCountrySelection() {
     if (!this.args.onCountrySelection) {


### PR DESCRIPTION


### What does this PR do?

This fixes a bug in the CountryChooser component not having an initial selection even though the `countryCode` or `countryCodes` (if multiple selection) named arguments have values.

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
