### PR TITLE
Fix age bracket chooser not passing up the mutated age bracket (DDAU impl)

### DIFF
--- a/addon/components/age-bracket-chooser/component.js
+++ b/addon/components/age-bracket-chooser/component.js
@@ -1,5 +1,4 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 import layout from './template';
 
 const AUDIENCE_AGE_BRACKETS = [
@@ -24,29 +23,18 @@ export default Component.extend({
 
   _selection: null,
 
-  ageBracket: computed('_selection', {
-    get() {
-      return (this._selection || {}).name;
-    },
-
-    set(_, value) {
-      this.set('_selection', AUDIENCE_AGE_BRACKETS.find((x) => x.name === value));
-
-      return value;
+  didReceiveAttrs() {
+    if (this.multiple) {
+      this.set(
+        '_selection',
+        (this.ageBrackets || []).map((v) => {
+          return AUDIENCE_AGE_BRACKETS.findBy('name', v);
+        })
+      );
+    } else {
+      this.set(
+        '_selection', AUDIENCE_AGE_BRACKETS.findBy('name', this.ageBracket)
+      );
     }
-  }),
-
-  ageBrackets: computed('_selection.[]', {
-    get() {
-      return (this._selection || []).map((x) => x.name);
-    },
-
-    set(_, value) {
-      this.set('_selection', (value || []).map((v) => {
-        return AUDIENCE_AGE_BRACKETS.find((x) => x.name === v);
-      }));
-      
-      return value;
-    }
-  })
+  }
 });

--- a/addon/components/age-bracket-chooser/template.hbs
+++ b/addon/components/age-bracket-chooser/template.hbs
@@ -1,4 +1,5 @@
 <label>{{label}}</label>
 {{item-chooser
   items=ageBracketValues multiple=multiple placeholder=placeholder
-  selection=_selection class=(if dark "item-chooser--dark") size=size}}
+  selection=_selection class=(if dark "item-chooser--dark") size=size
+  onSelect=onAgeBracketChange}}


### PR DESCRIPTION
### What does this PR do?

Fixes the age bracket chooser not updating the attribute it was passed down in its parent anymore.

DDAU* = Data Down Actions Up https://emberigniter.com/ddau-data-owner-mutate/

The `age-bracket-chooser` component has only one usage occurence in facade-web in the codebase.

Part of https://github.com/upfluence/backlog/issues/352

### What are the observable changes?

When selecting a value, the change is passed onto the parent component/controller/route via an action.

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
