### PR TITLE
modal-view : fix uncatched escape key

### DIFF
--- a/addon/components/modal-view.js
+++ b/addon/components/modal-view.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { observer } from '@ember/object';
-import { isNone } from '@ember/utils';
 import layout from '../templates/components/modal-view';
 
 export default Component.extend({
@@ -25,16 +24,18 @@ export default Component.extend({
     }
   }),
 
+  _handleEscapeKey(event) {
+    if (event.keyCode === 27) {
+      this.closeModal(event);
+    }
+  },
+
   didInsertElement() {
     if(!this.get('hidden')) {
       this._setupModal();
     }
 
-    this.$().keyup((e) => {
-      if (e.which === 27) {
-        this.closeModal(e);
-      }
-    });
+    this.element.addEventListener('keydown', this._handleEscapeKey.bind(this));
 
     this.$('button#close-x').click((e) => this.closeModal(e));
   },
@@ -56,5 +57,6 @@ export default Component.extend({
 
   willDestroyElement() {
     this.$(this.element).modal('hide');
+    this.element.removeEventListener('keydown', this._handleEscapeKey.bind(this));
   }
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the closeModal function not being called on Esc keydown.

(my two cents is that there is a listener on it in bootstrap via jQuery)

Related : https://github.com/upfluence/backlog/issues/329

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
