### PR TITLE
Ownership-selection: fix group selection

### DIFF
--- a/addon/components/ownership-selection-modal/groups/component.js
+++ b/addon/components/ownership-selection-modal/groups/component.js
@@ -4,16 +4,9 @@ import layout from './template';
 export default Component.extend({
   layout,
 
-  didReceiveAttrs() {
-    this._super();
-    if (this.entity) {
-      this.set('ownership', { id: this.entity.id, name: this.entity.name });
-    }
-  },
-
   actions: {
     updateOwnership(_, defer) {
-      this.saveOwnership(this.ownership.id).finally(defer.resolve);
+      this.saveOwnership(this.entity.ownedBy).finally(defer.resolve);
     }
   }
 });

--- a/addon/components/ownership-selection-modal/groups/template.hbs
+++ b/addon/components/ownership-selection-modal/groups/template.hbs
@@ -6,7 +6,7 @@
   <label class="margin-top-xx-sm">
     {{t "ownership_selection.groups.label"}}
   </label>
-  {{ownership-selection light=true entity=entity ownership=ownership}}
+  {{ownership-selection light=true entity=entity}}
 </div>
 
 <div class="modal-footer">

--- a/addon/components/ownership-selection-modal/groups/template.hbs
+++ b/addon/components/ownership-selection-modal/groups/template.hbs
@@ -12,7 +12,7 @@
 <div class="modal-footer">
   {{#loading-button
     slowAction="updateOwnership" class="upf-btn upf-btn--primary"
-    initiallyDisabled=(not ownership)}}
+    initiallyDisabled=(not entity.ownedBy)}}
     {{t "ownership_selection.groups.cta"}}
   {{/loading-button}}
 </div>

--- a/addon/components/ownership-selection/component.js
+++ b/addon/components/ownership-selection/component.js
@@ -1,6 +1,7 @@
-import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { observer } from '@ember/object';
+import { inject as service } from '@ember/service';
+
 import layout from './template';
 
 export default Component.extend({
@@ -12,10 +13,9 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
+
     this.currentUser.fetchOwnerships().then((ownerships) => {
-      if (ownerships.length > 1) {
-        this.set('display', true);
-      }
+      this.set('display', ownerships.length > 1);
 
       this.set(
         'ownerships',
@@ -24,20 +24,15 @@ export default Component.extend({
 
       this.set(
         'ownership',
-        ownerships.find((item) => {
-          return item.id === this.get('entity.ownedBy');
-        })
+        ownerships.find((item) => item.id === this.get('entity.ownedBy'))
       );
     });
   },
 
-  _1: observer('entity.name', function() {
-    this.set('_toggled', false);
+  _1: observer('entity.id', function() {
     this.set(
       'ownership',
-      this.ownerships.find((item) => {
-        return item.id === this.get('entity.ownedBy');
-      })
+      this.ownerships.find((item) => item.id === this.get('entity.ownedBy'))
     );
   }),
 
@@ -45,11 +40,5 @@ export default Component.extend({
     if (this.get('entity.ownedBy') !== this.get('ownership.id')) {
       this.set('entity.ownedBy', this.get('ownership.id'));
     }
-  }),
-
-  actions: {
-    toggle() {
-      this.toggleProperty('_toggled');
-    }
-  }
+  })
 });

--- a/addon/components/ownership-selection/template.hbs
+++ b/addon/components/ownership-selection/template.hbs
@@ -1,7 +1,7 @@
-{{#if display}}
+{{#if this.display}}
   <PowerSelect
-    @allowClear=true @options={{ownerships}} @selected={{ownership}}
-    @onChange={{action (mut ownership)}} @renderInPlace=true
+    @allowClear={{true}} @options={{this.ownerships}} @selected={{this.ownership}}
+    @onChange={{action (mut ownership)}} @renderInPlace={{true}}
     @placeholder={{t "ownership_selection.placeholder"}} as |o|>
     {{o.name}}
   </PowerSelect>

--- a/app/templates/components/ownership-selection-modal.hbs
+++ b/app/templates/components/ownership-selection-modal.hbs
@@ -1,4 +1,5 @@
-{{#modal-view hidden=hidden closeAction=closeModal container="body"
+{{#modal-view
+  hidden=hidden closeAction=closeModal container="body"
   centered=true title=header borderlessHeader=true}}
   <ul class="nav nav-tabs">
     {{#if tabs.groups}}
@@ -15,10 +16,10 @@
   </ul>
 
   {{#if peopleSelected}}
-    {{ownership-selection-modal/people entity=model
-      saveOwnership=(action "saveOwnership")}}
+    {{ownership-selection-modal/people
+      entity=model saveOwnership=(action "saveOwnership")}}
   {{else}}
-    {{ownership-selection-modal/groups entity=model
-      saveOwnership=(action "saveOwnership")}}
+    {{ownership-selection-modal/groups
+      entity=model saveOwnership=(action "saveOwnership")}}
   {{/if}}
 {{/modal-view}}

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
+    "ember-sinon-qunit": "^5.0.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^2.6.0",
     "ember-try": "^1.4.0",

--- a/tests/integration/components/ownership-selection-test.js
+++ b/tests/integration/components/ownership-selection-test.js
@@ -1,0 +1,157 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, getSettledState, waitUntil } from '@ember/test-helpers';
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import { hbs } from 'ember-cli-htmlbars';
+import {
+  clickTrigger, selectChoose, typeInSearch
+} from 'ember-power-select/test-support/helpers'
+import sinon from 'sinon';
+
+class CurrentUserServiceStub extends Service {
+  async fetchOwnerships() {
+    return [];
+  }
+}
+
+module('Integration | Component | ownership-selection', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register('service:current-user', CurrentUserServiceStub);
+  });
+
+  test('(no ownerships) it does not render anything', async function(assert) {
+    this.entity = null;
+
+    await render(hbs`{{ownership-selection entity=this.entity}}`);
+
+    assert.dom('.ember-basic-dropdown').doesNotExist();
+  });
+
+  // ownerships > 1 because there is always at least the current user's.
+  test('(w/ ownerships > 1) it renders the current ownerships and available options', async function(assert) {
+    this.entity = EmberObject.create({ name: 'My Entity', ownedBy: 'user:1' });
+    this.ownershipsStub = [
+      {
+        id: 'user:1',
+        name: 'Norman'
+      },
+      {
+        id: 'company:1',
+        name: 'Marvel'
+      },
+      {
+        id: 'team:1',
+        name: 'Spiderman Villains'
+      }
+    ];
+
+    const currentUserService = this.owner.lookup('service:current-user');
+
+    sinon.stub(currentUserService, 'fetchOwnerships').returns(
+      new Promise((resolve) => resolve(this.ownershipsStub))
+    );
+
+    await render(hbs`{{ownership-selection entity=this.entity}}`);
+
+    assert.dom('.ember-basic-dropdown').exists();
+    assert.dom(
+      '.ember-basic-dropdown .ember-power-select-selected-item'
+    ).containsText('Norman');
+
+    await clickTrigger();
+
+    const options = this.element.querySelectorAll('.ember-power-select-options li');
+
+    assert.equal(options.length, 3);
+    assert.dom(options[0]).containsText('Norman');
+    assert.dom(options[1]).containsText('Marvel');
+    assert.dom(options[2]).containsText('Spiderman Villains');
+  });
+
+  test('it correctly updates when the entity changes', async function(assert) {
+    this.entity = EmberObject.create({ name: 'My Entity', ownedBy: 'user:1' });
+    this.ownershipsStub = [
+      {
+        id: 'user:1',
+        name: 'Norman'
+      },
+      {
+        id: 'company:1',
+        name: 'Marvel'
+      },
+      {
+        id: 'team:1',
+        name: 'Spiderman Villains'
+      }
+    ];
+
+    const currentUserService = this.owner.lookup('service:current-user');
+
+    sinon.stub(currentUserService, 'fetchOwnerships').returns(
+      new Promise((resolve) => resolve(this.ownershipsStub))
+    );
+
+    await render(hbs`{{ownership-selection entity=this.entity}}`);
+
+    assert.dom(
+      '.ember-basic-dropdown .ember-power-select-selected-item'
+    ).containsText('Norman');
+
+    this.set('entity', EmberObject.create({ name: 'Entity #2', ownedBy: 'company:1' }));
+
+    await waitUntil(() => {
+      // Check for the settled state minus hasPendingTimers
+      // https://github.com/emberjs/ember-test-helpers/blob/master/API.md#getsettledstate
+      let { hasRunLoop, hasPendingRequests, hasPendingWaiters } = getSettledState();
+      if (hasRunLoop || hasPendingRequests || hasPendingWaiters) {
+        return false;
+      }
+
+      return true;
+    });
+
+    assert.dom(
+      '.ember-basic-dropdown .ember-power-select-selected-item'
+    ).containsText('Marvel');
+  });
+
+  test('it correctly assign a selected ownership to the entity', async function(assert) {
+    this.entity = EmberObject.create({ name: 'My Entity', ownedBy: 'user:1' });
+    this.ownershipsStub = [
+      {
+        id: 'user:1',
+        name: 'Norman'
+      },
+      {
+        id: 'company:1',
+        name: 'Marvel'
+      },
+      {
+        id: 'team:1',
+        name: 'Spiderman Villains'
+      }
+    ];
+
+    const currentUserService = this.owner.lookup('service:current-user');
+
+    sinon.stub(currentUserService, 'fetchOwnerships').returns(
+      new Promise((resolve) => resolve(this.ownershipsStub))
+    );
+
+    await render(hbs`{{ownership-selection entity=this.entity}}`);
+
+    assert.dom(
+      '.ember-basic-dropdown .ember-power-select-selected-item'
+    ).containsText('Norman');
+
+    await selectChoose('.ember-power-select-trigger', 'Spiderman Villains');
+
+    assert.dom(
+      '.ember-basic-dropdown .ember-power-select-selected-item'
+    ).containsText('Spiderman Villains');
+    assert.equal(this.entity.ownedBy, 'team:1');
+  });
+});

--- a/tests/integration/components/ownership-selection-test.js
+++ b/tests/integration/components/ownership-selection-test.js
@@ -4,9 +4,7 @@ import { render, getSettledState, waitUntil } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
-import {
-  clickTrigger, selectChoose, typeInSearch
-} from 'ember-power-select/test-support/helpers'
+import { clickTrigger, selectChoose } from 'ember-power-select/test-support/helpers'
 import sinon from 'sinon';
 
 class CurrentUserServiceStub extends Service {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,11 +2,13 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import setupSinon from 'ember-sinon-qunit';
 import QUnit from 'qunit';
 
 QUnit.config.hidepassed = false;
 
 setApplication(Application.create(config.APP));
+setupSinon();
 
 start({
   dockcontainer: true


### PR DESCRIPTION
### What does this PR do?

Fix the ownership selection being uncorrectly built off the entity itself 🤔  

Introduces the use fo [Sinon.js](https://sinonjs.org/) in testing. It's a really good library for stubs & mocks (based off what i read + recommendations in the Ember community). Why? Because even if Ember has support for creating stubs (for services for example), we can't stub a call to method to return what we want.

PS : This is based off my current knowledge of the testing features ahah 😅 

Related https://github.com/upfluence/backlog/issues/408

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
