### PR TITLE
Remove pull request ci trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - master
     tags:
       - v*
-  pull_request:
 
 env:
   NODE_VERSION: '10'


### PR DESCRIPTION
**What does this PR do?**
This PR removes the pull_request trigger as we're already running this workflow on each push.