### PR TITLE
Ember-upf-utils : Disabled the search skeleton display

### DIFF
--- a/addon/components/table-fluid/component.js
+++ b/addon/components/table-fluid/component.js
@@ -17,10 +17,14 @@ export default EmberCollection.extend(SlotsMixin, EKMixin, {
   _bottomReached: false,
   loading: false,
 
-  isReached: computed('items.reachedInfinity', '_bottomReached', function () {
+  isReached: computed('items.{currentPage,reachedInfinity,meta.totalPages}', '_bottomReached', function () {
     // Check infinity
     if (this.get('items.reachedInfinity') === null) {
       return this._bottomReached;
+    }
+
+    if (this.get('items.currentPage') >= this.get('items.meta.totalPages')) {
+      return true;
     }
 
     return this.get('items.reachedInfinity');


### PR DESCRIPTION
### What does this PR do?

Add condition to avoid extra call for match endpoint make by ember-infinity. Skeleton at the end of short search (ex: 22 influencers) isn't displayed now 

Related to: https://github.com/upfluence/backlog/issues/528

### What are the observable changes?
No extra loading skeleton for search

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled