### PR TITLE
Small Component Updates to allow "data-control-name" attributes to be passed as parameters

### DIFF
--- a/addon/components/age-bracket-chooser/component.js
+++ b/addon/components/age-bracket-chooser/component.js
@@ -8,6 +8,7 @@ export default Component.extend({
 
   classNames: ['form-element', 'age-chooser'],
   ageBracketValues: AUDIENCE_AGE_BRACKETS,
+  attributeBindings: ['data-control-name'],
 
   label: 'Age Bracket',
   placeholder: '-',

--- a/app/templates/components/country-chooser.hbs
+++ b/app/templates/components/country-chooser.hbs
@@ -1,4 +1,4 @@
-<div class="form-element country-chooser">
+<div class="form-element country-chooser" ...attributes>
   <label>{{this.label}}</label>
 
   {{item-chooser


### PR DESCRIPTION
### What does this PR do?

Updates dataAttributes of two components so that we can pass 'data-control-name' attributes as parameters

Related to: https://github.com/upfluence/backlog/issues/657

### What are the observable changes?
- Updated _country-choser_ component with Glimmer splattributes
- Updated _age-bracket-choser_ component with an attributeBindings param named 'data-control-name'

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled

