### PR TITLE
Add UEdit PDF Upload Modal

### DIFF
--- a/addon/components/u-edit/pdf-upload.hbs
+++ b/addon/components/u-edit/pdf-upload.hbs
@@ -1,0 +1,41 @@
+{{#modal-view hidden=@hidden closeAction=@closeAction title=(t "uedit_editor.toolbar.pdf.title") class="modal--pdf-upload"}}
+  <div class="modal-body">
+    <div class="form-group">
+      <label>{{t "uedit_editor.toolbar.pdf.by_url.label"}}</label>
+      <Input @value={{this.directURL}} @placeholder={{t "uedit_editor.toolbar.pdf.by_url.placeholder"}}
+             class="form-control upf-input" />
+    </div>
+
+    {{#drag-and-drop
+      class="drop-zone upf-align--center" onDragClass="drop-zone-active" onDropFiles=this.onDropFiles}}
+      <img src="/assets/@upfluence/ember-upf-utils/images/upload.svg" alt={{t "uedit_editor.toolbar.pdf.title"}} />
+
+      <br/>
+
+      {{#if this.processing}}
+        <h4>{{t "uedit_editor.toolbar.pdf.processing" filename=this.file.name}}</h4>
+      {{/if}}
+
+      <div class={{if this.processing 'hidden'}}>
+        <h3>{{t "uedit_editor.toolbar.pdf.drop_file"}}</h3>
+
+        <p>
+          {{t "uedit_editor.toolbar.pdf.or"}} <br />
+
+          {{file-uploader
+            file=this.droppedFile allowedExtensions=this.allowedExtensions headers=this.uploaderHeaders
+            extras=this.uploaderExtra text=(t "uedit_editor.toolbar.pdf.browse") beforeUpload=this.beforeUpload
+            didError=this.onError didUpload=this.didUpload}}
+        </p>
+      </div>
+    {{/drag-and-drop}}
+  </div>
+
+
+  <div class="modal-footer upf-align--center">
+    <button class="upf-btn upf-btn--primary" disabled={{and (not this.fileURL) (not this.directURL)}}
+            {{on "click" this.addPDF}}>
+      {{t "uedit_editor.toolbar.pdf.title"}}
+    </button>
+  </div>
+{{/modal-view}}

--- a/addon/components/u-edit/pdf-upload.js
+++ b/addon/components/u-edit/pdf-upload.js
@@ -1,0 +1,41 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class UEditPdfUploadComponent extends Component {
+  allowedExtensions = 'pdf';
+  uploaderHeaders = Object.freeze({ Scope: 'anonymous' });
+  uploaderExtra = Object.freeze({ privacy: 'public' });
+
+  @tracked file = {};
+  @tracked droppedFile = {};
+  @tracked processing = false;
+  @tracked directURL;
+  @tracked fileURL;
+
+  @action
+  onDropFiles(files) {
+    this.droppedFile = files[0];
+  }
+
+  @action
+  beforeUpload(file) {
+    this.file = file;
+    this.processing = true;
+  }
+
+  @action
+  didUploadError() {}
+
+  @action
+  didUpload({ artifact }) {
+    this.processing = false;
+    this.fileURL = artifact.url;
+  }
+
+  @action
+  addPDF() {
+    this.args.insertPDF(this.directURL || this.fileURL);
+    this.directURL = this.fileURL = null;
+  }
+}

--- a/app/components/u-edit/pdf-upload.js
+++ b/app/components/u-edit/pdf-upload.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/ember-upf-utils/components/u-edit/pdf-upload';

--- a/tests/integration/components/u-edit/pdf-upload-test.js
+++ b/tests/integration/components/u-edit/pdf-upload-test.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | u-edit/pdf-upload', function(hooks) {
+module('Integration | Component | u-edit/pdf-upload', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/tests/integration/components/u-edit/pdf-upload-test.js
+++ b/tests/integration/components/u-edit/pdf-upload-test.js
@@ -1,26 +1,44 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import Service from '@ember/service';
+import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+
+class SessionServiceStub extends Service {}
 
 module('Integration | Component | u-edit/pdf-upload', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  hooks.beforeEach(function () {
+    this.owner.register('service:session', SessionServiceStub);
+  });
 
-    await render(hbs`<UEdit::PdfUpload />`);
+  test('can not insert pdf if there is no url set', async function (assert) {
+    this.displayPDFUpload = true;
+    this.insertPDF = () => {};
 
-    assert.equal(this.element.textContent.trim(), '');
+    await render(hbs`<UEdit::PdfUpload @hidden={{not this.displayPDFUpload}} @insertPDF={{this.insertPDF}} />`);
 
-    // Template block usage:
-    await render(hbs`
-      <UEdit::PdfUpload>
-        template block text
-      </UEdit::PdfUpload>
-    `);
+    assert.dom('.modal.modal--pdf-upload button.upf-btn.upf-btn--primary').hasAttribute('disabled');
+  });
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+  test('an pdf is correctly added via its url in the editor', async function (assert) {
+    this.displayPDFUpload = true;
+    this.insertPDF = (url) => {
+      assert.equal(url, 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf');
+    };
+
+    await render(hbs`<UEdit::PdfUpload @hidden={{not this.displayPDFUpload}} @insertPDF={{this.insertPDF}} />`);
+
+    await fillIn(
+      '.modal.modal--pdf-upload input.upf-input',
+      'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'
+    );
+
+    assert.dom('.modal.modal--pdf-upload button.upf-btn.upf-btn--primary').hasNoAttribute('disabled');
+
+    await click('.modal.modal--pdf-upload button.upf-btn.upf-btn--primary');
+
+    assert.expect(2);
   });
 });

--- a/tests/integration/components/u-edit/pdf-upload-test.js
+++ b/tests/integration/components/u-edit/pdf-upload-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | u-edit/pdf-upload', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<UEdit::PdfUpload />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <UEdit::PdfUpload>
+        template block text
+      </UEdit::PdfUpload>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -91,6 +91,15 @@ uedit_editor:
       drop_file: Drop your file here
       or: or
       browse: Browse
+    pdf:
+      title: Add PDF
+      by_url:
+        label: "By URL:"
+        placeholder: https://example.org/file.pdf
+      processing: "Processing {filename}..."
+      drop_file: Drop your file here
+      or: or
+      browse: Browse
 errors:
   default:
     title: Oh...


### PR DESCRIPTION
### What does this PR do?
Adds necessary modal needed to upload PDF

Related to: https://github.com/upfluence/uedit/pull/16

### What are the observable changes?
A modal that supports PDF files and sends back the URL after uploading
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
