### PR TITLE
draft-display: Ensure that draft images doesn't overflow the container

### DIFF
--- a/app/styles/components/publishr/draft-display.less
+++ b/app/styles/components/publishr/draft-display.less
@@ -2,6 +2,10 @@
 
 .draft-display {
   display: flex;
+
+  img {
+    max-width: 100% !important;
+  }
 }
 
 .draft-display.draft-display--content-only {


### PR DESCRIPTION
### What does this PR do?

Big image broke the rendering of draft. This will ensure that the images didn't overflow the container.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
