### PR TITLE
Shared Triggers/Image modal: Show feedbacks about the uploaded file

### DIFF
--- a/addon/components/u-edit/shared-triggers/modals/image-upload.hbs
+++ b/addon/components/u-edit/shared-triggers/modals/image-upload.hbs
@@ -31,6 +31,26 @@
         </p>
       </div>
     {{/drag-and-drop}}
+
+    {{#if (and this.file.name (not this.processing))}}
+      <div class="uploaded-files margin-top-x-sm">
+        <label>{{t "uedit_editor.toolbar.image.processed_file.title"}}</label>
+
+        <div class="file">
+          <div class="details">
+            <div><i class="fa fa-picture-o text-size-7" /></div>
+
+            <div>
+              <span class="text-ellipsis-140">{{this.file.name}}</span>
+            </div>
+          </div>
+
+          <div class="status">
+            <i class="fa fa-check-circle text-color-success text-size-8" />
+          </div>
+        </div>
+      </div>
+    {{/if}}
   </div>
 
 

--- a/app/styles/components/image-upload-modal.less
+++ b/app/styles/components/image-upload-modal.less
@@ -1,4 +1,4 @@
-.modal.modal--image-upload {
+.modal.uedit__image-modal {
   .drop-zone {
     border-radius: @default-radius;
     border: 2px dashed @upf-primary-rock-blue-light;
@@ -14,5 +14,24 @@
 
   .drop-zone-active {
     border-color: @upf-primary-rock-blue;
+  }
+
+  .file {
+    border: 1px solid @border-color;
+    border-radius: @default-radius;
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    padding: @spacing-xx-sm;
+
+    .details {
+      display: flex;
+
+      div:last-child {
+        margin-left: @spacing-xx-sm;
+      }
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?

After the user uploaded an image to be added to the editor, show info about the filename.

Related to: https://github.com/upfluence/backlog/issues/809

### What are the observable changes?

<img width="692" alt="Screenshot 2021-07-06 at 13 45 06" src="https://user-images.githubusercontent.com/4022350/124605366-1ed45c00-de6c-11eb-9fa4-0ecf559347ad.png">


### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
