### PR TITLE
Handle integration disconnected alert

### DIFF
--- a/addon/activity-notifier/service.js
+++ b/addon/activity-notifier/service.js
@@ -165,6 +165,11 @@ export default Service.extend({
           `<b>Mailing error.</b> We ran into a problem with one of your Mailings. 
           <a href="${data.mailing_url}" target="_blank"><b>View my mailing</b></a>`
         );
+      case 'credential_disconnected':
+        return notificationErrorMessage(
+          `<b>Your ${data.integration_name} has been disconnected.</b> Please check your integration 
+          settings and reconnect it to avoid any issues. <a href="${data.integration_url}" target="_blank"><b>Reconnect</b></a>`
+        );
       default:
         return null;
     }

--- a/addon/activity-notifier/service.js
+++ b/addon/activity-notifier/service.js
@@ -15,7 +15,7 @@ const notificationMessage = function (message) {
 
 const notificationErrorMessage = function (message) {
   return {
-    title: `<i class="toast-title__icon upf-icon upf-icon--messages"></i>`,
+    title: `<i class="fa fa-info-circle" aria-hidden="true"></i>`,
     message: message,
     type: 'error'
   };


### PR DESCRIPTION
### What does this PR do?

Handle `credential_disconnected` notification

Related to: https://github.com/upfluence/backlog/issues/824

### What are the observable changes?
![Capture d’écran 2021-07-13 à 17 27 23](https://user-images.githubusercontent.com/32968230/125482608-36f623c1-a3e9-4029-b799-bb1fcc41566e.png)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

should we add `integration` between "Your" & "{{integration_name}}" ??
