### PR TITLE
Add maximum PDF size

### DIFF
--- a/addon/components/u-edit/shared-triggers/modals/file-uploader.hbs
+++ b/addon/components/u-edit/shared-triggers/modals/file-uploader.hbs
@@ -27,7 +27,7 @@
 
           {{file-uploader
             file=this.droppedFile allowedExtensions=this.allowedExtensions headers=this.uploaderHeaders
-            extra=this.uploaderExtra text=(t (concat "uedit_editor.toolbar." this.titleKey ".browse"))
+            extra=this.uploaderExtra maxSize="10 MB" text=(t (concat "uedit_editor.toolbar." this.titleKey ".browse"))
             beforeUpload=this.beforeUpload didError=this.onError didUpload=this.didUpload}}
         </p>
       </div>


### PR DESCRIPTION
### What does this PR do?
Add maximum PDF size to uedit PDF uploader
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: https://github.com/upfluence/cs/issues/199

### What are the observable changes?
None
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
