### PR TITLE
Pass access token through headers instead of url params

### DIFF
--- a/addon/exports/service.js
+++ b/addon/exports/service.js
@@ -13,6 +13,12 @@ export default Service.extend({
     return `${Configuration.exportUrl}/api/v1`;
   }),
 
+  _baseHeaders: computed('session.data.authenticated.access_token', function () {
+    return {
+      Authorization: `Bearer ${this.get('session.data.authenticated.access_token')}`
+    };
+  }),
+
   /*
    * @param {Object} source - Export source data
    *       @param {string}    source.from             - format: “type:id”,
@@ -60,9 +66,7 @@ export default Service.extend({
     return this.ajax.request(`${this._exportURL}/export`, {
       method: 'POST',
       contentType: 'application/json',
-      headers: {
-        Authorization: `Bearer ${this.get('session.data.authenticated.access_token')}`
-      },
+      headers: this._baseHeaders,
       data: JSON.stringify(payload)
     });
   },
@@ -89,28 +93,37 @@ export default Service.extend({
    ** }
    */
   getLimit(callback) {
-    let url = `${this._exportURL}/export/file/limit`;
-    let accessToken = this.get('session.data.authenticated.access_token');
-
-    return this.ajax.request(`${url}?access_token=${encodeURIComponent(accessToken)}`).then(callback);
+    return this.ajax
+      .request(`${this._exportURL}/export/file/limit`, {
+        method: 'GET',
+        headers: this._baseHeaders
+      })
+      .then(callback);
   },
 
   getAvailableExports() {
-    let accessToken = this.get('session.data.authenticated.access_token');
-    return this.ajax.request(`${this._exportURL}/discovery?access_token=${encodeURIComponent(accessToken)}`);
+    return this.ajax.request(`${this._exportURL}/discovery`, {
+      method: 'GET',
+      headers: this._baseHeaders
+    });
   },
 
   fetchEntities(type, callback) {
-    let url = `${this._exportURL}/entities/${type}`;
-    let accessToken = this.get('session.data.authenticated.access_token');
-
-    return this.ajax.request(`${url}?access_token=${encodeURIComponent(accessToken)}`).then(callback);
+    return this.ajax
+      .request(`${this._exportURL}/entities/${type}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.get('session.data.authenticated.access_token')}`
+        }
+      })
+      .then(callback);
   },
 
   searchEntities(keyword) {
-    let url = `${this._exportURL}/entities?s=${encodeURIComponent(keyword)}`;
-    let accessToken = this.get('session.data.authenticated.access_token');
-    return this.ajax.request(`${url}&access_token=${encodeURIComponent(accessToken)}`);
+    return this.ajax.request(`${this._exportURL}/entities?s=${encodeURIComponent(keyword)}`, {
+      method: 'GET',
+      headers: this._baseHeaders
+    });
   },
 
   createEntity(data, callback) {
@@ -120,9 +133,7 @@ export default Service.extend({
       .request(url, {
         method: 'POST',
         contentType: 'application/json',
-        headers: {
-          Authorization: `Bearer ${this.get('session.data.authenticated.access_token')}`
-        },
+        headers: this._baseHeaders,
         data: JSON.stringify(data)
       })
       .then(callback);

--- a/addon/exports/service.js
+++ b/addon/exports/service.js
@@ -112,9 +112,7 @@ export default Service.extend({
     return this.ajax
       .request(`${this._exportURL}/entities/${type}`, {
         method: 'GET',
-        headers: {
-          Authorization: `Bearer ${this.get('session.data.authenticated.access_token')}`
-        }
+        headers: this._baseHeaders
       })
       .then(callback);
   },


### PR DESCRIPTION
### What does this PR do?

- Stop passing access token through the URL parameters and use the `Authorization` header instead.

Related to https://github.com/upfluence/backlog/issues/1010

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist


- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
