### PR TITLE
Add access panel utility class to move away from the mixin

### DIFF
--- a/addon/utils/access-panel.js
+++ b/addon/utils/access-panel.js
@@ -1,0 +1,146 @@
+import { action } from '@ember/object';
+import { addObserver } from '@ember/object/observers';
+import { tracked } from '@glimmer/tracking';
+
+export default class {
+  @tracked displayAccessPanel = false;
+  @tracked displayArchived = false;
+  @tracked searchQuery = '';
+  @tracked contentLoading = false;
+  @tracked accessPanelEntities = [];
+
+  @tracked page = 1;
+  @tracked meta = {};
+
+  constructor(owner, config) {
+    this.owner = owner;
+    this.config = config;
+
+    [
+      `${config.model}.@each.archived`,
+      'displayAccessPanel',
+      'displayArchived',
+      'shouldReloadAccessPanel',
+      'searchQuery'
+    ].forEach((property) => {
+      addObserver(this, property, this.populateAccessPanel);
+    });
+  }
+
+  populateAccessPanel() {
+    if (!this.displayAccessPanel) {
+      return;
+    }
+
+    let model = this.config.model;
+
+    this.contentLoading = true;
+    this.storeService
+      .query(model, {
+        archived: this.displayArchived,
+        page: this.page,
+        s: this.searchQuery
+      })
+      .then((entities) => {
+        let current = this.model;
+        let meta = entities.meta;
+        entities = entities.toArray();
+
+        if (this.config.nestedModel) {
+          current = current[model];
+        }
+
+        if (current) {
+          entities.removeObject(current);
+          entities.splice(0, 0, current);
+        }
+
+        this.meta = meta;
+        this.accessPanelEntities = entities;
+        this.contentLoading = false;
+        this.shouldReloadAccessPanel = false;
+      });
+  }
+
+  get storeService() {
+    return this.owner.lookup('service:store');
+  }
+
+  get routerService() {
+    return this.owner.lookup('service:router');
+  }
+
+  get entityArchivingService() {
+    return this.owner.lookup('service:entity-archiving');
+  }
+
+  get intlService() {
+    return this.owner.lookup('service:intl');
+  }
+
+  get toastService() {
+    return this.owner.lookup('service:toast');
+  }
+
+  @action
+  toggleAccessPanel() {
+    this.displayArchived = false;
+    this.searchQuery = '';
+
+    this.displayAccessPanel = !this.displayAccessPanel;
+  }
+
+  @action
+  toggleDisplayArchived() {
+    this.displayArchived = !this.displayArchived;
+  }
+
+  @action
+  esc() {
+    this.displayAccessPanel = false;
+    this.displayArchived = false;
+    this.searchQuery = '';
+    this.routerService.transitionTo(this.config.backRoute);
+  }
+
+  @action
+  goToEntity(entity) {
+    this.displayAccessPanel = false;
+    this.displayArchived = false;
+    this.searchQuery = '';
+    entity.set('currentlyOpened', true);
+    this.routerService.transitionTo(this.config.entityRoute, entity.id, {
+      queryParams: this.config.backRouteParams
+    });
+  }
+
+  @action
+  didPageChange(page) {
+    this.page = page;
+    this.populateAccessPanel();
+  }
+
+  @action
+  bulkArchive(archivalAction, items, entityArchivingConfig) {
+    this.contentLoading = true;
+    this.entityArchivingService
+      .bulkToggleArchive(entityArchivingConfig.name, items.mapBy('id'), archivalAction)
+      .then(() => {
+        const _selectedItems = items;
+        items.setEach('selected', false);
+        this.accessPanelEntities.removeObjects(_selectedItems);
+      })
+      .catch(() => {
+        this.toastService.error(
+          this.intlService.t(entityArchivingConfig.error),
+          this.intlService.t(entityArchivingConfig.errorTitle)
+        );
+      })
+      .finally(() => (this.contentLoading = false));
+  }
+
+  @action
+  performSearch(keyword) {
+    this.searchQuery = keyword;
+  }
+}

--- a/app/styles/layout/side-hover-panel/styles.less
+++ b/app/styles/layout/side-hover-panel/styles.less
@@ -6,7 +6,7 @@
   // Container (and backdrop if specified) dimensions
   height: 100%;
   width: 100%;
-  z-index: 20;
+  z-index: 25;
   pointer-events: none;
 
   .panel-backdrop {

--- a/app/utils/access-panel.js
+++ b/app/utils/access-panel.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/ember-upf-utils/utilities/access-panel';


### PR DESCRIPTION
### What does this PR do?

In order to move a way from the Mixin pattern (that's not usable on Glimmer components for example), this moves the code from the [`HasAccessPanelMixin`](https://github.com/upfluence/ember-upf-utils/blob/master/addon/mixins/has-access-panel.js) to a utility class that needs to be instantiated.

It's usage can be found here:
- https://github.com/upfluence/publishr-admin-web/pull/394/files#diff-c47d147603435e492066d5b65f1d2336b45b535baaec312edbe1966acb431d6dR31
- https://github.com/upfluence/publishr-admin-web/pull/394/files#diff-0943c0bf98078b0b972e31312f77858776ddaf642958254f6f3ce8a767dc512eR50

Related to: https://github.com/upfluence/backlog/issues/1120

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
