### PR TITLE
move oss-components to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {
+    "@upfluence/oss-components": "^3.x",
     "@ember/optional-features": "^1.3.0",
     "@types/ember-data": "^3.16.15",
     "@types/ember-data__adapter": "^3.16.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "@onehilltech/ember-cli-google-analytics": "git+https://git@github.com/upfluence/ember-cli-google-analytics.git",
-    "@upfluence/oss-components": "^3.x",
     "bootstrap": "^3.3.7",
     "broccoli-funnel": "^3.x",
     "broccoli-merge-trees": "^3.0.1",
@@ -116,6 +115,9 @@
     "prettier": "^2.4.1",
     "qunit-dom": "^1.2.0",
     "typescript": "^4.4.4"
+  },
+  "peerDependencies": {
+    "@upfluence/oss-components": "^3.x"
   },
   "resolutions": {
     "@babel/helper-compilation-targets": "7.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,9 +1978,9 @@
     eslint-visitor-keys "^3.0.0"
 
 "@upfluence/oss-components@^3.x":
-  version "3.4.5"
-  resolved "https://npm.pkg.github.com/download/@upfluence/oss-components/3.4.5/022d7835690b3ba8a3084b60c3dd4224cc7ca9eef9daecaf77e591ae01cc175e#fa9eabc14445a85c15ee282106372927de7c41c0"
-  integrity sha512-199kNydmwcYvLBnU5TbkGKv+rUgKnRyS25zu6li4WeXdZc7Rr6VNKrcbc9ujbUii8XB8WtXrsE9+zqmsclkd8A==
+  version "3.8.2"
+  resolved "https://npm.pkg.github.com/download/@upfluence/oss-components/3.8.2/e1c47923a4b9ad5b627e3fb95a8466ad873ee1a29e6b09a78d2bee13635c6fac#ae50053fb3ac3ef3660aeae16ad20ab57d7b3952"
+  integrity sha512-JJTSi2NJ9KpNTJxRt5ld0ZNcYfkSMH/GViVCycmXuLjdaeqLoIQevaGFaac3QyHH7rtYoBBMVgcB3JC3+z08EQ==
   dependencies:
     "@upfluence/oss" "^3.x"
     babel-plugin-debug-macros "^0.3.1"
@@ -1989,15 +1989,16 @@
     ember-cli-ifa "^0.10.0"
     ember-cli-less "^1.5.3"
     ember-cli-typescript "^4.2.1"
+    ember-intl "^4.1.0"
     ember-named-blocks-polyfill "^0.2.4"
     ember-star-rating "^3.0.0"
     ember-truth-helpers "^3.0.0"
     ion-rangeslider "^2.3.1"
 
 "@upfluence/oss@^3.x":
-  version "3.0.7"
-  resolved "https://npm.pkg.github.com/download/@upfluence/oss/3.0.7/206b4458099dd6b8a5509d43c8f496cb8bd4698b01cbb58fde0bdfcacaa3caff#74f09b191461783314c94212f0e09b77bcd4e11e"
-  integrity sha512-pG+05rxRkscNbNnAnyKV+kKWbTvEKht6OAZMHDJrD9bILzsVwI8uk2vwMQtgiRbYSyZrXuZtvr7zrKgfPnLRUQ==
+  version "3.0.24"
+  resolved "https://npm.pkg.github.com/download/@upfluence/oss/3.0.24/76d8b793c2ef83494f3535eee42aebe4939778fcd8aea21580a6dc013a885c6a#912fee37626d5d31a9eedf3084f5fc43c81e023b"
+  integrity sha512-X+cCbqIFbo1ufssy4mYrTMK1wa+qDsLqrtsdHphfollGcR4XaZ3lpDDzJXgRzxz9cFMuRAaYN2fo7b3H5nY6GQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.x"
     bootstrap "^3.3.7"
@@ -2458,9 +2459,9 @@ asn1.js@^5.2.0:
     safer-buffer "^2.1.0"
 
 asn1@~0.2.3:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
-  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
 
@@ -7234,9 +7235,9 @@ extsprintf@1.3.0:
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
 
 extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
@@ -9134,10 +9135,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -9209,13 +9210,13 @@ jsonify@~0.0.0:
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsprim@^1.2.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
+  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.3.0"
-    json-schema "0.2.3"
+    json-schema "0.4.0"
     verror "1.10.0"
 
 just-extend@^4.0.2:
@@ -9961,12 +9962,24 @@ mime-db@1.50.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
   integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.26, mime-types@~2.1.24, mime-types@~2.1.7:
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.26, mime-types@~2.1.24:
   version "2.1.33"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
   integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
   dependencies:
     mime-db "1.50.0"
+
+mime-types@~2.1.7:
+  version "2.1.34"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
+  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  dependencies:
+    mime-db "1.51.0"
 
 mime@1.6.0, mime@^1.2.11:
   version "1.6.0"


### PR DESCRIPTION
### What does this PR do?

Accidentally noticed that `oss-components` was being setup by all projects including in their dependencies, causing weird behaviour where Font Awesome pro assets where not included because the last parent app was ember-upf-utils and not publishr-admin-web for example.

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#peerdependencies

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
