### PR TITLE
universal-section: display acquisition campaigns to the top

### DIFF
--- a/addon/components/universal-selection/component.js
+++ b/addon/components/universal-selection/component.js
@@ -27,35 +27,37 @@ export default Component.extend({
   _performSearch(resolve) {
     return this.exports.searchEntities(this.keyword, this.entityTypes).then((response) => {
       resolve(
-        Object.keys(response).reduce((acc, entityType) => {
-          if (response[entityType].length > 0 && !acc.find((item) => acc.includes(item.type))) {
-            acc.push({
-              groupName: entityType,
-              options: []
-            });
-          }
-          response[entityType].forEach((item) => {
-            acc.find((group) => {
-              let itemDisplayCondition = true;
+        Object.keys(response)
+          .sort((a) => (a === 'acquisition_campaign' ? -1 : 0))
+          .reduce((acc, entityType) => {
+            if (response[entityType].length > 0 && !acc.find((item) => acc.includes(item.type))) {
+              acc.push({
+                groupName: entityType,
+                options: []
+              });
+            }
+            response[entityType].forEach((item) => {
+              acc.find((group) => {
+                let itemDisplayCondition = true;
 
-              if (!this.displayEmptyEntities) {
-                itemDisplayCondition = item.total > 0;
-              }
+                if (!this.displayEmptyEntities) {
+                  itemDisplayCondition = item.total > 0;
+                }
 
-              if (group.groupName === entityType && itemDisplayCondition) {
-                group.options.push(
-                  ExportEntity.create({
-                    id: item.id,
-                    name: item.name,
-                    total: item.total,
-                    type: entityType
-                  })
-                );
-              }
+                if (group.groupName === entityType && itemDisplayCondition) {
+                  group.options.push(
+                    ExportEntity.create({
+                      id: item.id,
+                      name: item.name,
+                      total: item.total,
+                      type: entityType
+                    })
+                  );
+                }
+              });
             });
-          });
-          return acc;
-        }, [])
+            return acc;
+          }, [])
       );
     });
   },


### PR DESCRIPTION
### What does this PR do?

Display Live Capture campaigns at the top of the entities in the universal-selection component to showcase it.

Related to:  https://github.com/upfluence/backlog/issues/1193

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
