### PR TITLE
Migrate upf-alert to OSS::Alert component

### DIFF
--- a/addon/components/universal-export/file.hbs
+++ b/addon/components/universal-export/file.hbs
@@ -1,16 +1,11 @@
-<div class="modal-body text-center">
+<div class="modal-body">
   {{#if this.hasMultiType}}
     {{#if this.limitReached}}
-      <div class="upf-alert upf-alert--error">
-        <div class="upf-alert__text">
-          <span>
-            {{t "export_influencers.limit_reached" exportLimitLeft=this.exportLimitLeft htmlSafe=true}}
-          </span>
-        </div>
-      </div>
+      <OSS::Alert class="margin-bottom-px-12" @skin="error" @title={{t "export_influencers.limit_reached.title"}}
+                  @subtitle={{t "export_influencers.limit_reached.subtitle" exportLimitLeft=this.exportLimitLeft htmlSafe=true}} />
     {{/if}}
 
-    <div class="row margin-bottom-sm">
+    <div class="row margin-bottom-sm text-center">
       <div class="col-xs-6 col-xs-offset-3">
         <div class="text-size-5 text-color-default-lighter margin-bottom-xxx-sm">
           {{t "export_influencers.file.data"}}
@@ -26,7 +21,7 @@
     </div>
   {{/if}}
 
-  <div class="row">
+  <div class="row text-center">
     <div class="col-xs-6 col-xs-offset-3">
       <div class="text-size-5 text-color-default-lighter margin-bottom-xxx-sm">
         {{t "export_influencers.file.file_format"}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,7 +1,8 @@
 export_influencers:
   title: Move to
-  limit_reached: "You don't have enough exports credit for more than
-  <strong>{exportLimitLeft}</strong> influencers"
+  limit_reached:
+    title: Error
+    subtitle: "You don't have enough exports credit for more than <strong>{exportLimitLeft}</strong> influencers"
   tabs:
     in_app: In-App
     file: File


### PR DESCRIPTION
### What does this PR do?

Migrate upf-alert to OSS::Alert component

Related to: https://github.com/upfluence/backlog/issues/1683

### What are the observable changes?
See slack channel

### 🧑‍💻 Developer Heads Up

⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
