### PR TITLE
Added: catch export error and route it to communityThresholdManager

### DIFF
--- a/addon/exports/service.js
+++ b/addon/exports/service.js
@@ -8,6 +8,7 @@ export default Service.extend({
   store: service(),
   session: service(),
   ajax: service(),
+  communityThresholdManager: service(),
 
   _exportURL: computed(function () {
     return `${Configuration.exportUrl}/api/v1`;
@@ -36,14 +37,18 @@ export default Service.extend({
    *       @param {string} to                         - format: "type:id"
    */
   perform(source, destination) {
-    return this.ajax.request(`${this._exportURL}/export`, {
-      method: 'POST',
-      contentType: 'application/json',
-      headers: {
-        Authorization: `Bearer ${this.get('session.data.authenticated.access_token')}`
-      },
-      data: JSON.stringify({ source, destination })
-    });
+    return this.ajax
+      .request(`${this._exportURL}/export`, {
+        method: 'POST',
+        contentType: 'application/json',
+        headers: {
+          Authorization: `Bearer ${this.get('session.data.authenticated.access_token')}`
+        },
+        data: JSON.stringify({ source, destination })
+      })
+      .catch((error) => {
+        this.communityThresholdManager.processException(error);
+      });
   },
 
   exportToEntities(exportingFrom, exportingTo, influencerIds, filters, maxSize, tags) {


### PR DESCRIPTION
### What does this PR do?

When the perform method of export service is called, catch the possible errors and route them to the communityThresholdManager.

Related to: #[1849](https://github.com/upfluence/backlog/issues/1849)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled