### PR TITLE
Add the authenticated-requester-service

### DIFF
--- a/addon/services/authenticated-requester-service.ts
+++ b/addon/services/authenticated-requester-service.ts
@@ -1,0 +1,19 @@
+import Service, { inject as service } from '@ember/service';
+
+export default class AuthenticatedRequesterService extends Service {
+  @service declare session: any;
+
+  get headers(): Headers {
+    return new Headers({ Authorization: `Bearer ${this.accessToken}` });
+  }
+
+  private get accessToken(): string {
+    return this.session.data.authenticated.access_token;
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    'authenticated-requester-service': AuthenticatedRequesterService;
+  }
+}

--- a/app/services/authenticated-requester-service.js
+++ b/app/services/authenticated-requester-service.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/ember-upf-utils/services/authenticated-requester-service';

--- a/tests/unit/services/authenticated-requester-service-test.ts
+++ b/tests/unit/services/authenticated-requester-service-test.ts
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+
+class SessionServiceStub extends Service {
+  data = { authenticated: { access_token: 'foobar' } };
+}
+
+module('Unit | Service | authenticated-requester-service', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:session', SessionServiceStub);
+    this.authenticatedService = this.owner.lookup('service:authenticated-requester-service');
+  });
+
+  test('it returns the correct accessToken', function (assert) {
+    assert.equal(this.authenticatedService.accessToken, 'foobar');
+  });
+
+  test('it returns the correct Authorization headers', function (assert) {
+    const authorizationHeaders = this.authenticatedService.headers.get('Authorization');
+    assert.equal(authorizationHeaders, 'Bearer foobar');
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Add the authenticated-requester-service. It was initially in `publishr-admin` and need to be moved here to be use in other projects.

Related to: https://github.com/upfluence/backlog/issues/2320

### What are the observable changes?

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
