### PR TITLE
utils/address-form: always reset the state field when the country is updated

### DIFF
--- a/addon/components/utils/address-form.ts
+++ b/addon/components/utils/address-form.ts
@@ -37,16 +37,12 @@ export default class extends Component<UtilsAddressFormArgs> {
 
   @action
   applyCountry(country: CountryData): void {
-    set(this.args.address, 'countryCode', country.alpha2);
-    this.provincesForCountry = country.provinces ?? null;
-
-    if (
-      isEmpty(get(this.args.address, 'state')) &&
-      (get(this.args.address, 'countryCode') !== country.alpha2 || !this.provincesForCountry)
-    ) {
+    if (get(this.args.address, 'countryCode') !== country.alpha2) {
       set(this.args.address, 'state', '');
     }
 
+    set(this.args.address, 'countryCode', country.alpha2);
+    this.provincesForCountry = country.provinces ?? null;
     this.args.onChange(this.args.address, this._checkAddressValidity());
   }
 

--- a/tests/integration/components/utils/address-form-test.ts
+++ b/tests/integration/components/utils/address-form-test.ts
@@ -154,7 +154,7 @@ module('Integration | Component | utils/address-form', function (hooks) {
       );
       await click('[data-control-name="address-form-country"] .upf-input');
       await click('[data-control-name="address-form-country"] .upf-infinite-select__item:nth-child(2)');
-      assert.dom('[data-control-name="address-form-state"] input').hasValue('groot');
+      assert.dom('[data-control-name="address-form-state"] input').hasValue('');
 
       assert.ok(this.onChange.lastCall.calledWith(this.address, true));
     });


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where if you choose a country without mandatory state and fill it, then switch to a country with mandatory state, the previous State value is kept but the input is replaced with an `OSS::ProvinceSelector`, leading to the form being considered as valid while the UI displays no state.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
