### PR TITLE
Changed translation for age bracket chooser

### DIFF
--- a/addon/components/age-bracket-chooser/component.js
+++ b/addon/components/age-bracket-chooser/component.js
@@ -10,7 +10,7 @@ export default Component.extend({
   ageBracketValues: AUDIENCE_AGE_BRACKETS,
   attributeBindings: ['data-control-name'],
 
-  label: 'Age Bracket',
+  label: 'Age bracket',
   placeholder: '-',
   required: false,
   multiple: true,


### PR DESCRIPTION
### What does this PR do?

Changes a tiny trad on age picker

<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->
https://linear.app/upfluence/issue/ENG-1161/[facade-web]-disable-search-features-for-wednesday-users
### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
