### PR TITLE
Add hidePhoneNumber arg for address form component

### DIFF
--- a/addon/components/utils/address-form.hbs
+++ b/addon/components/utils/address-form.hbs
@@ -23,21 +23,23 @@
     </div>
   {{/unless}}
 
-  <div class="fx-col fx-gap-px-6">
-    <span class="font-size-md font-color-gray-500">
-      {{t "upf_utils.address_form.phone_number"}}
-    </span>
-    {{#if @usePhoneNumberInput}}
-      <OSS::PhoneNumberInput
-        @prefix={{this.phoneNumberPrefix}}
-        @number={{this.phoneNumber}}
-        @onChange={{this.onPhoneNumberUpdate}}
-        @validates={{this.onPhoneNumberValidation}}
-        data-control-name="address-form-phone" />
-    {{else}}
-      <OSS::InputContainer @value={{@address.phone}} data-control-name="address-form-phone" />
-    {{/if}}
-  </div>
+  {{#unless @hidePhoneNumber}}
+    <div class="fx-col fx-gap-px-6">
+      <span class="font-size-md font-color-gray-500">
+        {{t "upf_utils.address_form.phone_number"}}
+      </span>
+      {{#if @usePhoneNumberInput}}
+        <OSS::PhoneNumberInput
+          @prefix={{this.phoneNumberPrefix}}
+          @number={{this.phoneNumber}}
+          @onChange={{this.onPhoneNumberUpdate}}
+          @validates={{this.onPhoneNumberValidation}}
+          data-control-name="address-form-phone" />
+      {{else}}
+        <OSS::InputContainer @value={{@address.phone}} data-control-name="address-form-phone" />
+      {{/if}}
+    </div>
+  {{/unless}}
 
   <div class="fx-col fx-gap-px-6">
     <span class="font-size-md font-color-gray-500">

--- a/addon/components/utils/address-form.ts
+++ b/addon/components/utils/address-form.ts
@@ -10,8 +10,9 @@ import { CountryData, countries } from '@upfluence/oss-components/utils/country-
 
 interface UtilsAddressFormArgs {
   address: any;
-  usePhoneNumberInput: boolean;
+  usePhoneNumberInput?: boolean;
   hideNameAttrs?: boolean;
+  hidePhoneNumber?: boolean;
   useGoogleAutocomplete?: boolean;
   onChange(address: any, isValid: boolean): void;
 }
@@ -66,30 +67,30 @@ export default class extends Component<UtilsAddressFormArgs> {
 
     set(this.args.address, 'countryCode', country.alpha2);
     this.provincesForCountry = country.provinces ?? null;
-    this.args.onChange(this.args.address, this.checkAddressValidity());
+    this.args.onChange?.(this.args.address, this.checkAddressValidity());
   }
 
   @action
   applyProvince(province?: ProvinceData): void {
     set(this.args.address, 'state', province?.name || '');
-    this.args.onChange(this.args.address, this.checkAddressValidity());
+    this.args.onChange?.(this.args.address, this.checkAddressValidity());
   }
 
   @action
   onFieldUpdate(): void {
-    this.args.onChange(this.args.address, this.checkAddressValidity());
+    this.args.onChange?.(this.args.address, this.checkAddressValidity());
   }
 
   @action
   onPhoneNumberUpdate(prefix: string, number: number): void {
     set(this.args.address, 'phone', prefix + number);
-    this.args.onChange(this.args.address, this.checkAddressValidity());
+    this.args.onChange?.(this.args.address, this.checkAddressValidity());
   }
 
   @action
   onPhoneNumberValidation(passes: boolean): void {
     this.validPhoneNumber = !isEmpty(this.phoneNumber) && passes;
-    this.args.onChange(this.args.address, this.checkAddressValidity());
+    this.args.onChange?.(this.args.address, this.checkAddressValidity());
   }
 
   private checkAddressValidity(): boolean {
@@ -97,7 +98,7 @@ export default class extends Component<UtilsAddressFormArgs> {
       ? BASE_VALIDATED_ADDRESS_FIELDS
       : [...BASE_VALIDATED_ADDRESS_FIELDS, ...EXTRA_VALIDATED_ADDRESS_FIELDS];
 
-    if (this.args.usePhoneNumberInput && !this.validPhoneNumber) return false;
+    if (!this.args.hidePhoneNumber && this.args.usePhoneNumberInput && !this.validPhoneNumber) return false;
     if (!isEmpty(this.provincesForCountry) && isEmpty(get(this.args.address, 'state'))) return false;
 
     return !validatedAddressFields.some((addressAttr: string) => {

--- a/tests/integration/components/utils/address-form-test.ts
+++ b/tests/integration/components/utils/address-form-test.ts
@@ -45,6 +45,14 @@ module('Integration | Component | utils/address-form', function (hooks) {
   });
 
   module('Phone number input', function () {
+    test('It is hidden if @hidePhoneNumber is truthy', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @hidePhoneNumber={{true}} @useGoogleAutocomplete={{false}}
+                                @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-phone"]').doesNotExist();
+    });
+
     test('It displays the nice phone number input if the right arg is passed', async function (assert) {
       await render(
         hbs`<Utils::AddressForm @address={{this.address}} @usePhoneNumberInput={{true}} @useGoogleAutocomplete={{false}}
@@ -134,6 +142,26 @@ module('Integration | Component | utils/address-form', function (hooks) {
       await click('[data-control-name="address-form-country"] .upf-infinite-select__item:nth-child(1)');
       await fillIn('[data-control-name="address-form-zipcode"] > input', '3920392');
       await fillIn('[data-control-name="address-form-phone"] > input', '+4153920392');
+      await click('[data-control-name="address-form-state"] .upf-input');
+      await click('[data-control-name="address-form-state"] .upf-infinite-select__item:nth-child(1)');
+
+      assert.ok(this.onChange.lastCall.calledWith(this.address, true));
+    });
+
+    test('when all fields are filled and @hidePhoneNumber is true, the onChange action is called with truthy validity', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @hidePhoneNumber={{true}}
+                                @onChange={{this.onChange}} />`
+      );
+
+      await fillIn('[data-control-name="address-form-first-name"] > input', 'John');
+      await fillIn('[data-control-name="address-form-last-name"] > input', 'Marston');
+      await fillIn('[data-control-name="address-form-address1"] > input', '12 Foo bar');
+      await fillIn('[data-control-name="address-form-address2"] > input', 'Apt B');
+      await fillIn('[data-control-name="address-form-city"] > input', 'Blackwater');
+      await click('[data-control-name="address-form-country"] .upf-input');
+      await click('[data-control-name="address-form-country"] .upf-infinite-select__item:nth-child(1)');
+      await fillIn('[data-control-name="address-form-zipcode"] > input', '3920392');
       await click('[data-control-name="address-form-state"] .upf-input');
       await click('[data-control-name="address-form-state"] .upf-infinite-select__item:nth-child(1)');
 


### PR DESCRIPTION
### What does this PR do?

Add `hidePhoneNumber` arg for address form component

Related to: https://linear.app/upfluence/issue/ENG-1564/[ember-influencer]-new-attributespanelshippingaddress-component-and

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
