### PR TITLE
Add custom key for address form

### DIFF
--- a/addon/components/utils/address-form.hbs
+++ b/addon/components/utils/address-form.hbs
@@ -47,13 +47,13 @@
     </span>
     {{#if this.useGoogleAutocomplete}}
       <div class="fx-col google-autocomplete-input-container" data-control-name="address-form-address1">
-        <Input @value={{@address.address1}} class="upf-input" {{on "keyup" (fn this.onFieldUpdate "address1")}}
+        <Input @value={{get @address (concat this.addressKey "1")}} class="upf-input" {{on "keyup" (fn this.onFieldUpdate (concat this.addressKey "1"))}}
                {{did-insert this.initAutoCompletion}} />
       </div>
     {{else}}
       <OSS::InputContainer
-        @value={{@address.address1}}
-        @onChange={{fn this.onFieldUpdate "address1"}}
+        @value={{get @address (concat this.addressKey "1")}}
+        @onChange={{fn this.onFieldUpdate (concat this.addressKey "1")}}
         data-control-name="address-form-address1" />
     {{/if}}
   </div>
@@ -63,8 +63,8 @@
       {{t "upf_utils.address_form.line_2"}}
     </span>
     <OSS::InputContainer
-      @value={{@address.address2}}
-      @onChange={{fn this.onFieldUpdate "address2"}}
+      @value={{get @address (concat this.addressKey "2")}}
+      @onChange={{fn this.onFieldUpdate (concat this.addressKey "2")}}
       data-control-name="address-form-address2" />
   </div>
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <div class="fx-col fx-gap-px-12 margin-px-30">
   <Utils::AddressForm @address={{this.address}} @usePhoneNumberInput={{false}} @hideNameAttrs={{false}} @useGoogleAutocomplete={{true}}
-                      @onChange={{this.onChange}} />
+                      @onChange={{this.onChange}} @addressKey="line" />
   <Utils::SocialMediaHandle @handle="nomad.technologies" @socialNetwork="instagram" @errorMessage="This is an error"
                             @onChange={{this.onSocialMediaHandlerChanged}} @selectorOnly={{false}} />
 </div>

--- a/tests/integration/components/utils/address-form-test.ts
+++ b/tests/integration/components/utils/address-form-test.ts
@@ -274,4 +274,32 @@ module('Integration | Component | utils/address-form', function (hooks) {
       assert.ok(this.onChange.lastCall.calledWith(this.address, true));
     });
   });
+
+  module('When @addressKey is defined', (hooks) => {
+    hooks.beforeEach(function () {
+      this.address = EmberObject.create({
+        firstName: 'iam',
+        lastName: 'groot',
+        line1: 'iam',
+        line2: 'groot',
+        city: 'foo',
+        state: 'groot',
+        countryCode: 'US',
+        zipcode: 'iam',
+        phone: '+3348408934'
+      });
+    });
+
+    test('The address line is correctly update', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @hideNameAttrs={{true}}
+                                @onChange={{this.onChange}} @addressKey="line" />`
+      );
+      await fillIn('[data-control-name="address-form-address1"] > input', '12 Foo bar');
+      await fillIn('[data-control-name="address-form-address2"] > input', 'Apt B');
+
+      assert.equal(this.address.line1, '12 Foo bar');
+      assert.equal(this.address.line2, 'Apt B');
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Add custom key for address form. This update is necessary because the backend send to us in compensation-shipping-address the field `address1` and `line1` for shipping address in the influencer model

Related to: https://linear.app/upfluence/issue/ENG-1564/[ember-influencer]-new-attributespanelshippingaddress-component-and

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
