### PR TITLE
Fix validation for address form fields

### DIFF
--- a/addon/components/utils/address-form.ts
+++ b/addon/components/utils/address-form.ts
@@ -35,7 +35,7 @@ export default class extends Component<UtilsAddressFormArgs> {
   validPhoneNumber: boolean = true;
   countries: CountryData[] = countries;
   addressKey: AddressKey = 'address';
-  validatedAddressFields = BASE_VALIDATED_ADDRESS_FIELDS;
+  validatedAddressFields = [...BASE_VALIDATED_ADDRESS_FIELDS];
 
   constructor(owner: unknown, args: UtilsAddressFormArgs) {
     super(owner, args);
@@ -110,7 +110,8 @@ export default class extends Component<UtilsAddressFormArgs> {
     if (!isEmpty(this.provincesForCountry) && isEmpty(get(this.args.address, 'state'))) return false;
 
     return !this.validatedAddressFields.some((addressAttr: string) => {
-      const invalidPhone = addressAttr === 'phone' ? this.args.usePhoneNumberInput && !this.validPhoneNumber : false;
+      const invalidPhone =
+        addressAttr === 'phone' ? Boolean(this.args.usePhoneNumberInput) && !this.validPhoneNumber : false;
       const shortAddress =
         addressAttr === `${this.addressKey}1` ? (get(this.args.address, addressAttr) || '').length < 3 : false;
       const invalidCountryCode =
@@ -196,7 +197,7 @@ export default class extends Component<UtilsAddressFormArgs> {
     }
 
     if (!this.args.hideNameAttrs) {
-      this.validatedAddressFields = [...this.validatedAddressFields, ...EXTRA_VALIDATED_ADDRESS_FIELDS];
+      this.validatedAddressFields = this.validatedAddressFields.concat(EXTRA_VALIDATED_ADDRESS_FIELDS);
     }
   }
 }

--- a/tests/integration/components/utils/address-form-test.ts
+++ b/tests/integration/components/utils/address-form-test.ts
@@ -149,17 +149,7 @@ module('Integration | Component | utils/address-form', function (hooks) {
     });
 
     test('when all fields are filled and @hidePhoneNumber is true, the onChange action is called with truthy validity', async function (assert) {
-      this.address = EmberObject.create({
-        firstName: 'iam',
-        lastName: 'groot',
-        address1: 'iam',
-        address2: 'groot',
-        city: 'foo',
-        state: 'groot',
-        countryCode: 'US',
-        zipcode: 'iam'
-      });
-
+      this.address.phone = null;
       await render(
         hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @hidePhoneNumber={{true}}
                                 @onChange={{this.onChange}} />`

--- a/tests/integration/components/utils/address-form-test.ts
+++ b/tests/integration/components/utils/address-form-test.ts
@@ -149,6 +149,17 @@ module('Integration | Component | utils/address-form', function (hooks) {
     });
 
     test('when all fields are filled and @hidePhoneNumber is true, the onChange action is called with truthy validity', async function (assert) {
+      this.address = EmberObject.create({
+        firstName: 'iam',
+        lastName: 'groot',
+        address1: 'iam',
+        address2: 'groot',
+        city: 'foo',
+        state: 'groot',
+        countryCode: 'US',
+        zipcode: 'iam'
+      });
+
       await render(
         hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @hidePhoneNumber={{true}}
                                 @onChange={{this.onChange}} />`


### PR DESCRIPTION
### What does this PR do?

Fix validated address form fields:
The bug appears when no `phone` is present in the address and the `@hidePhoneNumber` is true. The validator return false because the `phone` is present in `BASE_VALIDATED_ADDRESS_FIELDS`. During the validation the `isEmpty(this.args.address.phone)` always fails.

Related to: https://linear.app/upfluence/issue/ENG-1756/mandatory-requirement-for-fields-are-not-respected

### What are the observable changes?

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
