### PR TITLE
Hc/vel 2958/generic error page rework

### DIFF
--- a/addon/components/http-errors-code.hbs
+++ b/addon/components/http-errors-code.hbs
@@ -1,41 +1,41 @@
-<div class="fx-col fx-malign-center fx-xalign-center fx-1 http-error-code-wrapper">
-  <div class="fx-row fx-xalign-center width-pc-70 fx-gap-px-100">
-    <div class="fx-col fx-gap-px-24 fx-1">
-      <span class="font-size-h1 font-weight-semibold" data-control-name="http-error-code-title">
-        {{t (concat "errors." @httpError ".title")}}
+<div class='fx-col fx-malign-center fx-xalign-center fx-1 http-error-code-wrapper'>
+  <div class='fx-row fx-xalign-center width-pc-70 fx-gap-px-100'>
+    <div class='fx-col fx-gap-px-24 fx-1'>
+      <span class='font-size-h1 font-weight-semibold' data-control-name='http-error-code-title'>
+        {{t (concat 'errors.' @httpError '.title')}}
       </span>
-      <span class="font-size-lg" data-control-name="http-error-code-subtitle">
-        {{t (concat "errors." @httpError ".subtitle")}}
+      <span class='font-size-lg' data-control-name='http-error-code-subtitle'>
+        {{t (concat 'errors.' @httpError '.subtitle')}}
       </span>
-      <div class="fx-col fx-gap-px-3 hints-container" data-control-name="http-error-code-hints">
+      <div class='fx-col fx-gap-px-3 hints-container' data-control-name='http-error-code-hints'>
         {{#each this.errorHints as |hint|}}
-          <div class="fx-row fx-gap-px-6 fx-xalign-center">
+          <div class='fx-row fx-gap-px-6 fx-xalign-center'>
             <OSS::Icon @icon={{hint.icon}} />
-            <span class="font-weight-semibold font-size-md">{{hint.label}}</span>
+            <span class='font-weight-semibold font-size-md'>{{hint.label}}</span>
           </div>
         {{/each}}
       </div>
-      <div class="fx-row fx-gap-px-12">
+      <div class='fx-row fx-gap-px-12'>
+        <OSS::Button
+          @skin='primary'
+          @icon={{if (eq @httpError '500') 'fa-redo' 'fa-arrow-left'}}
+          @label={{t (concat 'errors.' @httpError '.cta')}}
+          {{on 'click' (redirect-to url=(if (eq @httpError '404') '/' this.self))}}
+        />
         {{#if this.csChat}}
           <OSS::Button
-            @icon="fa-comment"
-            @label={{t (concat "errors." @httpError ".contact_support")}}
-            {{on "click" this.openSupportChannel}}
+            @icon='fa-comment'
+            @label={{t (concat 'errors.' @httpError '.contact_support')}}
+            {{on 'click' this.openSupportChannel}}
           />
         {{/if}}
-        <OSS::Button
-          @skin="primary"
-          @icon={{if (eq @httpError "404") "fa-arrow-left" "fa-redo"}}
-          @label={{t (concat "errors." @httpError ".cta")}}
-          {{on "click" (redirect-to url=(if (eq @httpError "404") "/" this.self))}}
-        />
       </div>
     </div>
 
     <img
-      src="/@upfluence/ember-upf-utils/assets/images/ufo-abduction.svg"
-      width="400"
-      alt={{t "errors.default.img_alt"}}
+      src='/@upfluence/ember-upf-utils/assets/images/ufo-abduction.svg'
+      width='400'
+      alt={{t 'errors.default.img_alt'}}
     />
   </div>
 </div>

--- a/addon/components/http-errors-code.hbs
+++ b/addon/components/http-errors-code.hbs
@@ -1,41 +1,41 @@
-<div class='fx-col fx-malign-center fx-xalign-center fx-1 http-error-code-wrapper'>
-  <div class='fx-row fx-xalign-center width-pc-70 fx-gap-px-100'>
-    <div class='fx-col fx-gap-px-24 fx-1'>
-      <span class='font-size-h1 font-weight-semibold' data-control-name='http-error-code-title'>
-        {{t (concat 'errors.' @httpError '.title')}}
+<div class="fx-col fx-malign-center fx-xalign-center fx-1 http-error-code-wrapper">
+  <div class="fx-row fx-xalign-center width-pc-70 fx-gap-px-100">
+    <div class="fx-col fx-gap-px-24 fx-1">
+      <span class="font-size-h1 font-weight-semibold" data-control-name="http-error-code-title">
+        {{t (concat "errors." @httpError ".title")}}
       </span>
-      <span class='font-size-lg' data-control-name='http-error-code-subtitle'>
-        {{t (concat 'errors.' @httpError '.subtitle')}}
+      <span class="font-size-lg" data-control-name="http-error-code-subtitle">
+        {{t (concat "errors." @httpError ".subtitle")}}
       </span>
-      <div class='fx-col fx-gap-px-3 hints-container' data-control-name='http-error-code-hints'>
+      <div class="fx-col fx-gap-px-3 hints-container" data-control-name="http-error-code-hints">
         {{#each this.errorHints as |hint|}}
-          <div class='fx-row fx-gap-px-6 fx-xalign-center'>
+          <div class="fx-row fx-gap-px-6 fx-xalign-center">
             <OSS::Icon @icon={{hint.icon}} />
-            <span class='font-weight-semibold font-size-md'>{{hint.label}}</span>
+            <span class="font-weight-semibold font-size-md">{{hint.label}}</span>
           </div>
         {{/each}}
       </div>
-      <div class='fx-row fx-gap-px-12'>
+      <div class="fx-row fx-gap-px-12">
         <OSS::Button
-          @skin='primary'
-          @icon={{if (eq @httpError '500') 'fa-redo' 'fa-arrow-left'}}
-          @label={{t (concat 'errors.' @httpError '.cta')}}
-          {{on 'click' (redirect-to url=(if (eq @httpError '404') '/' this.self))}}
+          @skin="primary"
+          @icon={{if (eq @httpError "500") "fa-redo" "fa-arrow-left"}}
+          @label={{t (concat "errors." @httpError ".cta")}}
+          {{on "click" (redirect-to url=(if (eq @httpError "404") "/" this.self))}}
         />
         {{#if this.csChat}}
           <OSS::Button
-            @icon='fa-comment'
-            @label={{t (concat 'errors.' @httpError '.contact_support')}}
-            {{on 'click' this.openSupportChannel}}
+            @icon="fa-comment"
+            @label={{t (concat "errors." @httpError ".contact_support")}}
+            {{on "click" this.openSupportChannel}}
           />
         {{/if}}
       </div>
     </div>
 
     <img
-      src='/@upfluence/ember-upf-utils/assets/images/ufo-abduction.svg'
-      width='400'
-      alt={{t 'errors.default.img_alt'}}
+      src="/@upfluence/ember-upf-utils/assets/images/ufo-abduction.svg"
+      width="400"
+      alt={{t "errors.default.img_alt"}}
     />
   </div>
 </div>

--- a/addon/components/http-errors-code.ts
+++ b/addon/components/http-errors-code.ts
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 import type { IntlService } from 'ember-intl';
 
 interface HTTPErrorsCodeArgs {
-  httpError: '404' | '500';
+  httpError: '404' | '500' | 'default';
 }
 
 export default class extends Component<HTTPErrorsCodeArgs> {

--- a/addon/http-errors/template.hbs
+++ b/addon/http-errors/template.hbs
@@ -1,15 +1,1 @@
-<div class="row">
-  <div class="col-xs-11 upf-align--absolute-center upf-align--right">
-    <h1>
-      <OSS::Icon @icon="fa-exclamation-triangle" class="upf-status-page__error-reason" />
-      {{t "errors.default.title"}}
-    </h1>
-    <div class="row">
-      <div class="col-xs-6 pull-right">
-        <div class="text-size-7 text-color-blue-gray">
-          {{t "errors.default.subtitle"}}
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<HttpErrorsCode @httpError='default' />

--- a/addon/http-errors/template.hbs
+++ b/addon/http-errors/template.hbs
@@ -1,1 +1,1 @@
-<HttpErrorsCode @httpError='default' />
+<HttpErrorsCode @httpError="default" />

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -19,7 +19,7 @@ upf_utils:
       postal_code: Enter postal code
       city: Enter city
   social_media_handle:
-    input_placeholder: "@Handle or account URL"
+    input_placeholder: '@Handle or account URL'
     networks:
       instagram: Instagram
       twitter: Twitter
@@ -27,8 +27,8 @@ upf_utils:
       twitch: Twitch
       youtube: YouTube
   product_row:
-    product_options: "{nbProductOptions} options"
-    option_selected: "Option: {optionName}"
+    product_options: '{nbProductOptions} options'
+    option_selected: 'Option: {optionName}'
     button:
       select_label: Select
     tag:
@@ -60,9 +60,9 @@ uedit_editor:
     image:
       title: Add Image
       by_url:
-        label: "By URL:"
+        label: 'By URL:'
         placeholder: https://example.org/image.png
-      processing: "Processing {filename}..."
+      processing: 'Processing {filename}...'
       processed_file:
         title: Uploaded Files
       drop_file: Drop your file here
@@ -72,9 +72,9 @@ uedit_editor:
     pdf:
       title: Add PDF
       by_url:
-        label: "By URL:"
+        label: 'By URL:'
         placeholder: https://example.org/file.pdf
-      processing: "Processing {filename}..."
+      processing: 'Processing {filename}...'
       processed_file:
         title: Uploaded Files
       drop_file: Drop your file here
@@ -83,8 +83,19 @@ uedit_editor:
       cancel: Cancel
 errors:
   default:
-    title: Oh...
-    subtitle: It seems something went wrong.
+    title: Whoops, something went wrong!
+    subtitle: Looks like a space hiccup! Our playful alien friends might have taken this page for a fast cosmic joyride.
+    cta: Back to homepage
+    contact_support: Chat with our support
+    support_message: |
+      Dear Support Team,
+
+      I've come across an error while trying to access a page. Could you please assist me with this issue?
+
+      Thank you
+    hints:
+      technical_issue: We encountered an unexpected technical issue
+      contact_support: If the problem persists, contact our support
     img_alt: UFO Abduction Illustration
   404:
     title: Uh-oh, error 404!


### PR DESCRIPTION
### What does this PR do?

This PR updates the look of the default error page, to match 404 et 500 error pages' design

### What are the observable changes?
When we encounter a server error other than 404 or 500, the new default error page is displayed.
Works for Upfluence and Wednesday.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Migrated touched components to Glimmer Components
- [x] Properly labeled
