### PR TITLE
[VEL-3593/VEL-3588]  Remove unused ember-tether

### DIFF
--- a/addon/activity-notifier/service.js
+++ b/addon/activity-notifier/service.js
@@ -1,6 +1,6 @@
 import { alias, notEmpty } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
-import { run } from '@ember/runloop';
+import { cancel, later } from '@ember/runloop';
 import { observer } from '@ember/object';
 import { getOwner } from '@ember/application';
 import Configuration from '@upfluence/ember-upf-utils/configuration';
@@ -61,7 +61,7 @@ export default Service.extend({
     this._isRunning = false;
 
     if (this._timer) {
-      run.cancel(this._timer);
+      cancel(this._timer);
     }
   },
 
@@ -80,7 +80,7 @@ export default Service.extend({
       .then((p) => {
         this._from = p.next;
         this.displayNotifications(p.notifications);
-        this._timer = run.later(this, this.fetchNotifications, this.waitTime());
+        this._timer = later(this, this.fetchNotifications, this.waitTime());
       })
       .finally(() => {
         this._inFetch = false;

--- a/addon/components/feature-flagged/template.hbs
+++ b/addon/components/feature-flagged/template.hbs
@@ -1,4 +1,4 @@
-{{#if allowedFeature}}
+{{#if this.allowedFeature}}
   {{yield}}
 {{else}}
   {{yield to="inverse"}}

--- a/addon/mixins/activity-runner.js
+++ b/addon/mixins/activity-runner.js
@@ -1,12 +1,12 @@
-import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
-import { run } from '@ember/runloop';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 
 export default Mixin.create({
   activityNotifier: service(),
 
   init() {
     this._super();
-    run.later(this, () => this.activityNotifier.start(), 3000);
+    later(this, () => this.activityNotifier.start(), 3000);
   }
 });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ember-cli-less": "^2.0.6",
     "ember-cli-typescript": "^4.2.1",
     "ember-named-blocks-polyfill": "^0.2.4",
-    "ember-tether": "^1.0.0-beta.2",
     "ember-uploader": "^2.x",
     "moment": "^2.29.4",
     "tinycolor2": "^1.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ dependencies:
   ember-named-blocks-polyfill:
     specifier: ^0.2.4
     version: 0.2.5
-  ember-tether:
-    specifier: ^1.0.0-beta.2
-    version: 1.0.0(@babel/core@7.23.9)
   ember-uploader:
     specifier: ^2.x
     version: 2.0.0(@babel/core@7.23.9)
@@ -5657,27 +5654,6 @@ packages:
     resolution: {integrity: sha512-SaOCEdh+wnt2jFUV2Qb32m7LXyElvFwW3NKNaEJyi5PGQNwxfqpkc0KI6AbQANKgdj/40U2UC0WuGThFwuEUaA==}
     dev: true
 
-  /broccoli-funnel@1.2.0:
-    resolution: {integrity: sha512-0pbFNUA5Ml+gPPd58Rj/M26OS21+bMiV0F+m6+9OVzAhAdppVLxylSsXfWAt2WOD3kS+D8UsDv6GSmnZhbw/dw==}
-    dependencies:
-      array-equal: 1.0.2
-      blank-object: 1.0.2
-      broccoli-plugin: 1.3.1
-      debug: 2.6.9
-      exists-sync: 0.0.4
-      fast-ordered-set: 1.0.3
-      fs-tree-diff: 0.5.9
-      heimdalljs: 0.2.6
-      minimatch: 3.1.2
-      mkdirp: 0.5.6
-      path-posix: 1.0.0
-      rimraf: 2.7.1
-      symlink-or-copy: 1.3.1
-      walk-sync: 0.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /broccoli-funnel@2.0.2:
     resolution: {integrity: sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==}
     engines: {node: ^4.5 || 6.* || >= 7.*}
@@ -7561,20 +7537,6 @@ packages:
     engines: {node: ^4.5 || 6.* || >= 7.*}
     dev: true
 
-  /ember-cli-node-assets@0.2.2:
-    resolution: {integrity: sha512-pFyjlhzwx2FxAmkxSVJvP+i+MwHDhmgsmma1ZQbFLYwBeufo1GIzqSJUfStcpOE1NDg8fXm2yZVVzdZYf9lW2w==}
-    engines: {node: '>= 4'}
-    dependencies:
-      broccoli-funnel: 1.2.0
-      broccoli-merge-trees: 1.2.4
-      broccoli-source: 1.1.0
-      debug: 2.6.9
-      lodash: 4.17.21
-      resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /ember-cli-normalize-entity-name@1.0.0:
     resolution: {integrity: sha512-rF4P1rW2P1gVX1ynZYPmuIf7TnAFDiJmIUFI1Xz16VYykUAyiOCme0Y22LeZq8rTzwBMiwBwoE3RO4GYWehXZA==}
     dependencies:
@@ -8255,18 +8217,6 @@ packages:
       - supports-color
     dev: true
 
-  /ember-tether@1.0.0(@babel/core@7.23.9):
-    resolution: {integrity: sha512-/qfAJZmsHSWrNGC0Ry6jqwpxr/ksO+fnBJIJM5DbDfRw4HlSQDw+pACpcLKCrgSW/JU+hIdedIvKwIbPbR9Dzw==}
-    engines: {node: ^4.5 || 6.* || >= 7.*}
-    dependencies:
-      ember-cli-babel: 6.18.0(@babel/core@7.23.9)
-      ember-cli-node-assets: 0.2.2
-      tether: 1.4.7
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    dev: false
-
   /ember-truth-helpers@3.1.1:
     resolution: {integrity: sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==}
     engines: {node: 10.* || >= 12}
@@ -8833,11 +8783,6 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
-
-  /exists-sync@0.0.4:
-    resolution: {integrity: sha512-cy5z7K+05RFxHAWY37dSDkPWmuTi+VzrA/xLwPDHmwQPMnO/kVhu6jheGaItlnNRoOE6f5MAjxy3VEupfrHigQ==}
-    deprecated: Please replace with usage of fs.existsSync
-    dev: false
 
   /exists-sync@0.1.0:
     resolution: {integrity: sha512-qEfFekfBVid4b14FNug/RNY1nv+BADnlzKGHulc+t6ZLqGY4kdHGh1iFha8lnE3sJU/1WzMzKRNxS6EvSakJUg==}
@@ -13747,10 +13692,6 @@ packages:
       - walrus
       - whiskers
     dev: true
-
-  /tether@1.4.7:
-    resolution: {integrity: sha512-Z0J1aExjoFU8pybVkQAo/vD2wfSO63r+XOPfWQMC5qtf1bI7IWqNk4MiyBcgvvnY8kqnY06dVdvwTK2S3PU/Fw==}
-    dev: false
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -2,21 +2,6 @@
 
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
-// Ember's browser support policy is changing, and IE11 support will end in
-// v4.0 onwards.
-//
-// See https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy
-//
-// If you need IE11 support on a version of Ember that still offers support
-// for it, uncomment the code block below.
-//
-// const isCI = Boolean(process.env.CI);
-// const isProduction = process.env.EMBER_ENV === 'production';
-//
-// if (isCI || isProduction) {
-//   browsers.push('ie 11');
-// }
-
 module.exports = {
   browsers
 };


### PR DESCRIPTION
### What does this PR do?

Remove unused ember-tether as the addon is not really using it.

This must be merged after: https://github.com/upfluence/ember-influencer/pull/572 & https://github.com/upfluence/hypertable/pull/208

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
