### PR TITLE
Updated: wording for email received toast + intl

### DIFF
--- a/addon/services/activity-watcher.ts
+++ b/addon/services/activity-watcher.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import { Observable } from '@upfluence/hyperevents/helpers/observable';
 import EventsService, { ResourceEvent, prefixPath } from '@upfluence/hyperevents/services/events-service';
 import ToastService, { ToastOptions } from '@upfluence/oss-components/services/toast';
+import { IntlService } from 'ember-intl';
 
 type NotificationEvent = {
   resource: string;
@@ -47,69 +48,87 @@ function renderNotificationMessageWithAvatar(message: string, title: string, ava
 }
 
 type NotificationRendererMap = {
-  [key: string]: (data: any) => RenderedNotification;
+  [key: string]: (data: any, intl?: IntlService) => RenderedNotification;
 };
 
 const renderersByNotificationType: NotificationRendererMap = {
-  mailing_email_received: (data: any) => {
+  mailing_email_received: (data: any, intl: IntlService) => {
     return renderNotificationMessageWithAvatar(
-      `Email from <b>${data.influencer_name}</b>
-       <a href="${data.entity_url}" target="_blank">Reply</a>`,
-      'New email',
+      intl.t('notifications.mailing_email_received.description', {
+        influencer_name: data.influencer_name,
+        entity_url: data.entity_url
+      }),
+      intl.t('notifications.mailing_email_received.title'),
       data.influencer_avatar
     );
   },
-  conversation_email_received: (data: any) => {
+  conversation_email_received: (data: any, intl: IntlService) => {
     return renderNotificationMessageWithAvatar(
-      `Email from <b>${data.influencer_name}</b>
-       <a href="${data.entity_url}" target="_blank">Reply</a>`,
-      'New email',
+      intl.t('notifications.conversation_email_received.description', {
+        influencer_name: data.influencer_name,
+        entity_url: data.entity_url
+      }),
+      intl.t('notifications.conversation_email_received.title'),
       data.influencer_avatar
     );
   },
-  direct_message_received: (data: any) => {
+  direct_message_received: (data: any, intl: IntlService) => {
     return renderNotificationMessageWithAvatar(
-      `Message from <b>${data.influencer_name}</b>
-       <a href="${data.entity_url}" target="_blank">Reply</a>`,
-      'New message',
+      intl.t('notifications.direct_message_received.description', {
+        influencer_name: data.influencer_name,
+        entity_url: data.entity_url
+      }),
+      intl.t('notifications.direct_message_received.title'),
       data.influencer_avatar
     );
   },
-  publishr_application_received: (data: any) => {
+  publishr_application_received: (data: any, intl: IntlService) => {
     return renderNotificationMessageWithAvatar(
-      `Application from <b>${data.influencer_name}</b> in <b>${data.campaign_name}</b>
-       <a href="${data.url}" target="_blank">See application</a>`,
-      'New application',
+      intl.t('notifications.publishr_application_received.description', {
+        influencer_name: data.influencer_name,
+        campaign_name: data.campaign_name,
+        url: data.url
+      }),
+      intl.t('notifications.publishr_application_received.title'),
       data.influencer_avatar
     );
   },
-  publishr_draft_created: (data: any) => {
+  publishr_draft_created: (data: any, intl: IntlService) => {
     return renderNotificationMessageWithAvatar(
-      `Draft by <b>${data.influencer_name}</b> in <b>${data.campaign_name}</b>
-       <a href="${data.url}" target="_blank">Review</a>`,
-      'New draft',
+      intl.t('notifications.publishr_draft_created.description', {
+        influencer_name: data.influencer_name,
+        campaign_name: data.campaign_name,
+        url: data.url
+      }),
+      intl.t('notifications.publishr_draft_created.title'),
       data.influencer_avatar
     );
   },
-  list_recommendation: (data: any) => {
+  list_recommendation: (data: any, intl: IntlService) => {
     return renderNotificationMessage(
-      `You have <b>${data.count}</b> new recommendations for your <b>${data.list_name}</b> list
-       <a href="${data.url}" target="_blank">View</a>`,
-      'New recommendations'
+      intl.t('notifications.list_recommendation.description', {
+        count: data.count,
+        list_name: data.list_name,
+        url: data.url
+      }),
+      intl.t('notifications.list_recommendation.title')
     );
   },
-  thread_failure_summary: (data: any) => {
+  thread_failure_summary: (data: any, intl: IntlService) => {
     return renderNotificationErrorMessage(
-      `<b>Mailing error.</b> We ran into a problem with one of your Mailings.
-         <a href="${data.mailing_url}" target="_blank">View my mailing</a>`,
-      'Thread failure'
+      intl.t('notifications.thread_failure_summary.description', {
+        mailing_url: data.mailing_url
+      }),
+      intl.t('notifications.thread_failure_summary.title')
     );
   },
-  credential_disconnected: (data: any) => {
+  credential_disconnected: (data: any, intl: IntlService) => {
     return renderNotificationErrorMessage(
-      `<b>Your ${data.integration_name} has been disconnected.</b> Please check your integration.
-      settings and reconnect it to avoid any issues. <a href="${data.integration_url}" target="_blank">Reconnect</a>`,
-      'Integration disconnected'
+      intl.t('notifications.credential_disconnected.description', {
+        integration_name: data.integration_name,
+        integration_url: data.integration_url
+      }),
+      intl.t('notifications.credential_disconnected.title')
     );
   }
 };
@@ -117,6 +136,7 @@ const renderersByNotificationType: NotificationRendererMap = {
 export default class ActivityWatcher extends Service {
   @service declare eventsService: EventsService;
   @service declare toast: ToastService;
+  @service declare intl: IntlService;
 
   private declare _observer: Observable<ResourceEvent> | null;
 
@@ -169,7 +189,7 @@ export default class ActivityWatcher extends Service {
       return null;
     }
 
-    return renderer(evt.payload.data || {});
+    return renderer(evt.payload.data, this.intl || {});
   }
 }
 

--- a/tests/unit/services/activity-watcher-test.ts
+++ b/tests/unit/services/activity-watcher-test.ts
@@ -43,7 +43,7 @@ module('Unit | Service | activity-watcher', function (hooks) {
           }
         },
         wantInfoTitle: 'New email',
-        wantInfoMessage: `Email from <b>bozito</b>
+        wantInfoMessage: `You have a new email from bozito!<br>
           <a href="https://entity.url.com" target="_blank">Reply</a>`
       },
       {
@@ -57,8 +57,8 @@ module('Unit | Service | activity-watcher', function (hooks) {
           }
         },
         wantInfoTitle: 'New email',
-        wantInfoMessage: `Email from <b>bozito</b>
-           <a href="https://entity.url.com" target="_blank">Reply</a>`
+        wantInfoMessage: `You have a new email from bozito!<br>
+          <a href="https://entity.url.com" target="_blank">Reply</a>`
       },
       {
         notification: {
@@ -140,8 +140,8 @@ module('Unit | Service | activity-watcher', function (hooks) {
           }
         },
         wantErrorTitle: 'Integration disconnected',
-        wantErrorMessage: `<b>Your woop has been disconnected.</b> Please check your integration.
-          settings and reconnect it to avoid any issues. <a href="https://inte-gration.com" target="_blank">Reconnect</a>`
+        wantErrorMessage: `<b>Your woop has been disconnected.</b> Please check your integration settings and reconnect it to avoid any issues.
+          <a href="https://inte-gration.com" target="_blank">Reconnect</a>`
       }
     ];
 
@@ -152,13 +152,13 @@ module('Unit | Service | activity-watcher', function (hooks) {
         const infoStub = sinon
           .stub(this.owner.lookup('service:toast'), 'info')
           .callsFake((message: string, title: string) => {
-            assert.equal(trimAll(message), trimAll(testCase.wantInfoMessage));
+            assert.true(trimAll(message).includes(trimAll(testCase.wantInfoMessage)));
             assert.equal(title, testCase.wantInfoTitle);
           });
         const errorStub = sinon
           .stub(this.owner.lookup('service:toast'), 'error')
           .callsFake((message: string, title: string) => {
-            assert.equal(trimAll(message), trimAll(testCase.wantErrorMessage));
+            assert.true(trimAll(message).includes(trimAll(testCase.wantErrorMessage)));
             assert.equal(title, testCase.wantErrorTitle);
           });
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -155,3 +155,44 @@ utms:
     campaign: UTM campaign*
     campaign_placeholder: e.g. product launch winter 2022
   preview: Preview of your tracking URL
+notifications:
+  mailing_email_received:
+    title: New email
+    description: |
+      You have a new email from {influencer_name}!<br>
+      <a href="{entity_url}" target="_blank">Reply</a>
+  conversation_email_received: 
+    title: New email
+    description: |
+      You have a new email from {influencer_name}!<br>
+      <a href="{entity_url}" target="_blank">Reply</a>
+  direct_message_received:
+    title: New message
+    description: |
+      Message from <b>{influencer_name}</b>
+      <a href="{entity_url}" target="_blank">Reply</a>
+  publishr_application_received:
+    title: New application
+    description: |
+      Application from <b>{influencer_name}</b> in <b>{campaign_name}</b>
+      <a href="{url}" target="_blank">See application</a>
+  publishr_draft_created:
+    title: New draft
+    description: |
+      Draft by <b>{influencer_name}</b> in <b>{campaign_name}</b>
+      <a href="{url}" target="_blank">Review</a>
+  list_recommendation:
+    title: New recommendations
+    description: |
+      You have <b>{count}</b> new recommendations for your <b>{list_name}</b> list
+      <a href="{url}" target="_blank">View</a>
+  thread_failure_summary:
+    title: Thread failure
+    description: |
+      <b>Mailing error.</b> We ran into a problem with one of your Mailings.
+      <a href="{mailing_url}" target="_blank">View my mailing</a>
+  credential_disconnected:
+    title: Integration disconnected
+    description: |
+      <b>Your {integration_name} has been disconnected.</b> Please check your integration settings and reconnect it to avoid any issues.
+      <a href="{integration_url}" target="_blank">Reconnect</a>


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Updated wording of email received notification, transferred all notifications' text to the translation file, updated tests.

Related to: #[DRA-27](https://linear.app/upfluence/issue/DRA-27/[plg]-reply-button-toast-message-does-not-appear-on-new-line)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->
![DRA-27](https://github.com/user-attachments/assets/d8d6d121-3f0e-47ba-84b3-90dfc59d7c7b)

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
