### PR TITLE
ActivityWatcher now disconnects users when token_destroyed is received

### DIFF
--- a/addon/services/activity-watcher.ts
+++ b/addon/services/activity-watcher.ts
@@ -188,7 +188,7 @@ export default class ActivityWatcher extends Service {
   }
 
   private checkIfUserNeedsToBeDisconnected(event: NotificationEvent): void {
-    if (this.session.data.authenticated.access_token === event.payload.data.accessToken) {
+    if (this.session.data.authenticated.access_token === event.payload.data.access_token) {
       this.session.tooManyConnections = true;
       this.session.invalidate();
     }

--- a/addon/services/activity-watcher.ts
+++ b/addon/services/activity-watcher.ts
@@ -137,6 +137,7 @@ export default class ActivityWatcher extends Service {
   @service declare eventsService: EventsService;
   @service declare toast: ToastService;
   @service declare intl: IntlService;
+  @service declare session: any;
 
   private declare _observer: Observable<ResourceEvent> | null;
 
@@ -147,7 +148,7 @@ export default class ActivityWatcher extends Service {
 
     this._observer = this.eventsService.watch(prefixPath('/notification'));
     this._observer.subscribe((evt: NotificationEvent) => {
-      this._processEvent(evt);
+      this.processEvent(evt);
     });
   }
 
@@ -160,8 +161,12 @@ export default class ActivityWatcher extends Service {
     this._observer = null;
   }
 
-  private _processEvent(evt: NotificationEvent): void {
-    const notif = this._buildNotification(evt);
+  private processEvent(evt: NotificationEvent): void {
+    if (evt.payload.notification_type === 'token_destroyed') {
+      this.checkIfUserNeedsToBeDisconnected(evt);
+      return;
+    }
+    const notif = this.buildNotification(evt);
 
     if (!notif) {
       return;
@@ -182,7 +187,14 @@ export default class ActivityWatcher extends Service {
     }
   }
 
-  private _buildNotification(evt: NotificationEvent): RenderedNotification | null {
+  private checkIfUserNeedsToBeDisconnected(event: NotificationEvent): void {
+    if (this.session.data.authenticated.access_token === event.payload.data.accessToken) {
+      this.session.tooManyConnections = true;
+      this.session.invalidate();
+    }
+  }
+
+  private buildNotification(evt: NotificationEvent): RenderedNotification | null {
     const renderer = renderersByNotificationType[evt.payload.notification_type];
 
     if (!renderer) {

--- a/tests/unit/services/activity-watcher-test.ts
+++ b/tests/unit/services/activity-watcher-test.ts
@@ -48,7 +48,7 @@ module('Unit | Service | activity-watcher', function (hooks) {
         payload: {
           notification_type: 'token_destroyed',
           data: {
-            accessToken: 'some-token'
+            access_token: 'some-token'
           }
         }
       });


### PR DESCRIPTION
### What does this PR do?

ActivityWatcher now disconnects users when token_destroyed is received

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
