### PR TITLE
Update utm-link-builder to match new designs/specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Lint & Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: (!contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/tags/v'))
     timeout-minutes: 10
     steps:
@@ -39,7 +39,7 @@ jobs:
         run: pnpm test:ember
   release:
     name: Release Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: test
     if: contains(github.ref, 'refs/tags/v')
     timeout-minutes: 10

--- a/addon/components/utils/utm-link-builder.hbs
+++ b/addon/components/utils/utm-link-builder.hbs
@@ -1,43 +1,81 @@
-<div class="utm-container fx-1 fx-gap-px-12" ...attributes>
-  <div class="fx-1 fx-row fx-malign-center fx-xalign-center fx-gap-px-12">
-    <OSS::Badge @icon="far fa-chart-bar" />
-    <div class="fx-col fx-1">
-      <span class="text-style-bold">{{t "utms.title"}}</span>
-      <span class="text-color-gray-500">{{t "utms.description"}}</span>
-    </div>
-    <OSS::ToggleSwitch @value={{this.utmsEnabled}} @onChange={{this.toggleSwitchUpdate}} />
-  </div>
-  {{#if this.utmsEnabled}}
-    <hr />
+<OSS::TogglableSection
+  @title={{this.title}}
+  @subtitle={{this.subtitle}}
+  @badgeIcon="far fa-chart-bar"
+  @toggled={{this.utmsEnabled}}
+  @onChange={{this.toggleSwitchUpdate}}
+  ...attributes
+>
+  <:contents>
     <div class="activated-utms fx-col fx-1 fx-gap-px-12">
-      <span class="font-color-gray-500 text-size-5">{{t "utms.fields.source"}}</span>
-      <OSS::InputContainer @value={{this.utmSource}}
-                           @placeholder={{t "utms.fields.source_placeholder"}}
-                           {{on "keyup" (fn this.notifyChanges "utmSource")}}
-                           data-control-name="utm_source_input" />
-      <span class="font-color-gray-500 text-size-5">{{t "utms.fields.medium"}}</span>
-      <OSS::InputContainer @value={{this.utmMedium}}
-                           @placeholder={{t "utms.fields.medium_placeholder"}}
-                           {{on "keyup" (fn this.notifyChanges "utmMedium")}}
-                           data-control-name="utm_medium_input" />
-      <span class="font-color-gray-500 text-size-5">{{t "utms.fields.campaign"}}</span>
-      <OSS::InputContainer @value={{this.utmCampaign}}
-                           @placeholder={{t "utms.fields.campaign_placeholder"}}
-                           {{on "keyup" (fn this.notifyChanges "utmCampaign")}}
-                           data-control-name="utm_campaign_input" />
+      <div class="fx-row">
+        <span class="font-color-gray-500 font-size-md">
+          {{t "utms.fields.source"}}
+        </span>
+        <span class="font-color-error-500">
+          *
+        </span>
+      </div>
+      <OSS::InputContainer
+        @value={{this.utmSource}}
+        @placeholder={{t "utms.fields.source_placeholder"}}
+        @feedbackMessage={{this.validationErrors.utmSource}}
+        data-control-name="utm_source_input"
+        {{on "focusout" (fn this.validateField "utmSource")}}
+        {{on "keyup" (fn this.notifyChanges "utmSource")}}
+      />
+
+      <div class="fx-row">
+        <span class="font-color-gray-500 font-size-md">
+          {{t "utms.fields.medium"}}
+        </span>
+        <span class="font-color-error-500">
+          *
+        </span>
+      </div>
+      <OSS::InputContainer
+        @value={{this.utmMedium}}
+        @placeholder={{t "utms.fields.medium_placeholder"}}
+        @feedbackMessage={{this.validationErrors.utmMedium}}
+        data-control-name="utm_medium_input"
+        {{on "focusout" (fn this.validateField "utmMedium")}}
+        {{on "keyup" (fn this.notifyChanges "utmMedium")}}
+      />
+
+      <div class="fx-row">
+        <span class="font-color-gray-500 font-size-md">
+          {{t "utms.fields.campaign"}}
+        </span>
+        <span class="font-color-error-500">
+          *
+        </span>
+      </div>
+      <OSS::InputContainer
+        @value={{this.utmCampaign}}
+        @placeholder={{t "utms.fields.campaign_placeholder"}}
+        @feedbackMessage={{this.validationErrors.utmCampaign}}
+        data-control-name="utm_campaign_input"
+        {{on "focusout" (fn this.validateField "utmCampaign")}}
+        {{on "keyup" (fn this.notifyChanges "utmCampaign")}}
+      />
     </div>
-    <hr />
-    <div class="fx-1 fx-col fx-gap-px-6">
-      <span class="text-size-5 font-color-gray-500">{{t "utms.preview"}}</span>
-      <p class="link-preview">
-        <span class="text-color-bright-purple">{{this.fieldUrl}}</span>
-        <span class="text-color-gray-500">&quest;utm_source=<span
-                class="text-color-bright-purple">{{this.fieldSource}}</span></span>
-        <span class="text-color-gray-500">&amp;utm_medium=<span
-                class="text-color-bright-purple">{{this.fieldMedium}}</span></span>
-        <span class="text-color-gray-500">&amp;utm_campaign=<span
-                class="text-color-bright-purple">{{this.fieldCampaign}}</span></span>
-      </p>
-    </div>
-  {{/if}}
-</div>
+    {{#if this.displayPreview}}
+      <hr />
+      <div class="fx-1 fx-col fx-gap-px-6">
+        <span class="text-size-5 font-color-gray-500">{{t "utms.preview"}}</span>
+        <p class="link-preview">
+          <span class="text-color-bright-purple">{{this.fieldUrl}}</span>
+          <span class="text-color-gray-500">&quest;utm_source=<span
+              class="text-color-bright-purple"
+            >{{this.fieldSource}}</span></span>
+          <span class="text-color-gray-500">&amp;utm_medium=<span
+              class="text-color-bright-purple"
+            >{{this.fieldMedium}}</span></span>
+          <span class="text-color-gray-500">&amp;utm_campaign=<span
+              class="text-color-bright-purple"
+            >{{this.fieldCampaign}}</span></span>
+        </p>
+      </div>
+    {{/if}}
+  </:contents>
+</OSS::TogglableSection>

--- a/addon/components/utils/utm-link-builder.hbs
+++ b/addon/components/utils/utm-link-builder.hbs
@@ -4,6 +4,7 @@
   @badgeIcon="far fa-chart-bar"
   @toggled={{this.utmsEnabled}}
   @onChange={{this.toggleSwitchUpdate}}
+  class="utm-container"
   ...attributes
 >
   <:contents>

--- a/addon/components/utils/utm-link-builder.hbs
+++ b/addon/components/utils/utm-link-builder.hbs
@@ -62,18 +62,16 @@
     {{#if this.displayPreview}}
       <hr />
       <div class="fx-1 fx-col fx-gap-px-6">
-        <span class="text-size-5 font-color-gray-500">{{t "utms.preview"}}</span>
+        <span class="font-size-md font-color-gray-500">{{t "utms.preview"}}</span>
         <p class="link-preview">
-          <span class="text-color-bright-purple">{{this.fieldUrl}}</span>
-          <span class="text-color-gray-500">&quest;utm_source=<span
-              class="text-color-bright-purple"
-            >{{this.fieldSource}}</span></span>
-          <span class="text-color-gray-500">&amp;utm_medium=<span
-              class="text-color-bright-purple"
-            >{{this.fieldMedium}}</span></span>
-          <span class="text-color-gray-500">&amp;utm_campaign=<span
-              class="text-color-bright-purple"
-            >{{this.fieldCampaign}}</span></span>
+          <span class="font-color-primary-500">{{this.fieldUrl}}</span>
+          <span>
+            &quest;utm_source=<span class="font-color-primary-500">{{this.fieldSource}}</span>
+          </span>
+          <span>&amp;utm_medium=<span class="font-color-primary-500">{{this.fieldMedium}}</span></span>
+          <span class="text-color-gray-500">
+            &amp;utm_campaign=<span class="font-color-primary-500">{{this.fieldCampaign}}</span>
+          </span>
         </p>
       </div>
     {{/if}}

--- a/addon/components/utils/utm-link-builder.hbs
+++ b/addon/components/utils/utm-link-builder.hbs
@@ -8,56 +8,62 @@
 >
   <:contents>
     <div class="activated-utms fx-col fx-1 fx-gap-px-12">
-      <div class="fx-row">
-        <span class="font-color-gray-500 font-size-md">
-          {{t "utms.fields.source"}}
-        </span>
-        <span class="font-color-error-500">
-          *
-        </span>
+      <div class="fx-col fx-gap-px-6">
+        <div class="fx-row">
+          <span class="font-color-gray-500 font-size-md">
+            {{t "utms.fields.source"}}
+          </span>
+          <span class="font-color-error-500">
+            *
+          </span>
+        </div>
+        <OSS::InputContainer
+          @value={{this.utmSource}}
+          @placeholder={{t "utms.fields.source_placeholder"}}
+          @feedbackMessage={{this.validationErrors.utmSource}}
+          data-control-name="utm_source_input"
+          {{on "focusout" (fn this.validateField "utmSource")}}
+          {{on "keyup" (fn this.notifyChanges "utmSource")}}
+        />
       </div>
-      <OSS::InputContainer
-        @value={{this.utmSource}}
-        @placeholder={{t "utms.fields.source_placeholder"}}
-        @feedbackMessage={{this.validationErrors.utmSource}}
-        data-control-name="utm_source_input"
-        {{on "focusout" (fn this.validateField "utmSource")}}
-        {{on "keyup" (fn this.notifyChanges "utmSource")}}
-      />
 
-      <div class="fx-row">
-        <span class="font-color-gray-500 font-size-md">
-          {{t "utms.fields.medium"}}
-        </span>
-        <span class="font-color-error-500">
-          *
-        </span>
+      <div class="fx-col fx-gap-px-6">
+        <div class="fx-row">
+          <span class="font-color-gray-500 font-size-md">
+            {{t "utms.fields.medium"}}
+          </span>
+          <span class="font-color-error-500">
+            *
+          </span>
+        </div>
+        <OSS::InputContainer
+          @value={{this.utmMedium}}
+          @placeholder={{t "utms.fields.medium_placeholder"}}
+          @feedbackMessage={{this.validationErrors.utmMedium}}
+          data-control-name="utm_medium_input"
+          {{on "focusout" (fn this.validateField "utmMedium")}}
+          {{on "keyup" (fn this.notifyChanges "utmMedium")}}
+        />
       </div>
-      <OSS::InputContainer
-        @value={{this.utmMedium}}
-        @placeholder={{t "utms.fields.medium_placeholder"}}
-        @feedbackMessage={{this.validationErrors.utmMedium}}
-        data-control-name="utm_medium_input"
-        {{on "focusout" (fn this.validateField "utmMedium")}}
-        {{on "keyup" (fn this.notifyChanges "utmMedium")}}
-      />
 
-      <div class="fx-row">
-        <span class="font-color-gray-500 font-size-md">
-          {{t "utms.fields.campaign"}}
-        </span>
-        <span class="font-color-error-500">
-          *
-        </span>
+      <div class="fx-col fx-gap-px-6">
+        <div class="fx-row">
+          <span class="font-color-gray-500 font-size-md">
+            {{t "utms.fields.campaign"}}
+          </span>
+          <span class="font-color-error-500">
+            *
+          </span>
+        </div>
+        <OSS::InputContainer
+          @value={{this.utmCampaign}}
+          @placeholder={{t "utms.fields.campaign_placeholder"}}
+          @feedbackMessage={{this.validationErrors.utmCampaign}}
+          data-control-name="utm_campaign_input"
+          {{on "focusout" (fn this.validateField "utmCampaign")}}
+          {{on "keyup" (fn this.notifyChanges "utmCampaign")}}
+        />
       </div>
-      <OSS::InputContainer
-        @value={{this.utmCampaign}}
-        @placeholder={{t "utms.fields.campaign_placeholder"}}
-        @feedbackMessage={{this.validationErrors.utmCampaign}}
-        data-control-name="utm_campaign_input"
-        {{on "focusout" (fn this.validateField "utmCampaign")}}
-        {{on "keyup" (fn this.notifyChanges "utmCampaign")}}
-      />
     </div>
     {{#if this.displayPreview}}
       <hr />

--- a/addon/components/utils/utm-link-builder.ts
+++ b/addon/components/utils/utm-link-builder.ts
@@ -76,11 +76,13 @@ export default class UtilsUtmLinkBuilder extends Component<UtilsUtmLinkBuilderAr
           [field]: { type: 'error', value: this.intl.t('utms.errors.blank_field') }
         }
       };
+      this.notifyChanges();
       return;
     }
 
     delete this.validationErrors[field];
     this.validationErrors = { ...this.validationErrors };
+    this.notifyChanges();
   }
 
   get utmFields(): UtmFields {

--- a/addon/components/utils/utm-link-builder.ts
+++ b/addon/components/utils/utm-link-builder.ts
@@ -9,19 +9,19 @@ import { IntlService } from 'ember-intl';
 
 import { FeedbackMessage } from '@upfluence/oss-components/components/o-s-s/input-container';
 
+export type UtmFields = {
+  utm_source: string;
+  utm_medium: string;
+  utm_campaign: string;
+};
+
 interface UtilsUtmLinkBuilderArgs {
   url: string;
   title?: string;
   subtitle?: string;
   displayPreview?: boolean;
-  onChange(url: string, utmsEnabled: boolean, formValid: boolean, utmFields: UTM_FIELDS): void;
+  onChange(url: string, utmsEnabled: boolean, formValid: boolean, utmFields: UtmFields): void;
 }
-
-type UTM_FIELDS = {
-  utm_source: string;
-  utm_medium: string;
-  utm_campaign: string;
-};
 
 export default class UtilsUtmLinkBuilder extends Component<UtilsUtmLinkBuilderArgs> {
   @service declare intl: IntlService;
@@ -83,7 +83,7 @@ export default class UtilsUtmLinkBuilder extends Component<UtilsUtmLinkBuilderAr
     this.validationErrors = { ...this.validationErrors };
   }
 
-  get utmFields(): UTM_FIELDS {
+  get utmFields(): UtmFields {
     return {
       utm_campaign: this.utmCampaign,
       utm_medium: this.utmMedium,

--- a/addon/components/utils/utm-link-builder.ts
+++ b/addon/components/utils/utm-link-builder.ts
@@ -5,9 +5,9 @@ import { isBlank } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { IntlService } from 'ember-intl';
+import { type IntlService } from 'ember-intl';
 
-import { FeedbackMessage } from '@upfluence/oss-components/components/o-s-s/input-container';
+import { type FeedbackMessage } from '@upfluence/oss-components/components/o-s-s/input-container';
 
 export type UtmFields = {
   utm_source: string;

--- a/app/styles/components/utm-link-builder.less
+++ b/app/styles/components/utm-link-builder.less
@@ -1,8 +1,4 @@
 .utm-container {
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--border-radius-sm);
-  padding: var(--spacing-px-18);
-
   .link-preview {
     font-size: 0;
     word-break: break-all;

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -136,12 +136,14 @@ utms:
   title: Enable UTM parameters
   description: Track performance data from Google Analytics
   fields:
-    source: UTM source*
+    source: UTM source
     source_placeholder: e.g. Upfluence, Youtube, Instagram
-    medium: UTM medium*
+    medium: UTM medium
     medium_placeholder: e.g. description, caption, footer
-    campaign: UTM campaign*
+    campaign: UTM campaign
     campaign_placeholder: e.g. product launch winter 2022
+  errors:
+    blank_field: This field can’t be blank as the UTM parameters are enabled.
   preview: Preview of your tracking URL
 notifications:
   mailing_email_received:


### PR DESCRIPTION
### What does this PR do?

Update utm-link-builder to match new designs/specs to:
- use the `OSS::TogglableSection` component
- update the style of the mandatory field "*" marker
- add some validation on inputs' blur event
- allow the preview to be disabled (enabled by default for BC)

TODO:
- double check usage in workflow app
- might need to allow validation errors to be passed as args too when the validation is done by the upper level

### What are the observable changes?

![Screenshot 2025-02-17 at 09 04 30](https://github.com/user-attachments/assets/3b216d05-5612-481a-898f-b57f94dc6e29)

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
