### PR TITLE
Create new address inline with Google place API

### DIFF
--- a/addon/components/utils/address-inline.hbs
+++ b/addon/components/utils/address-inline.hbs
@@ -1,8 +1,4 @@
-<div class="fx-col fx-gap-px-6 fx-1">
-  {{@value.address}}
-  <span class="font-color-gray-500">
-    {{t "upf_utils.address_inline"}}
-  </span>
+<div class="fx-col fx-gap-px-6 fx-1" ...attributes>
   {{#if this.useGoogleAutocomplete}}
     <div class="fx-col fx-1 google-autocomplete-input-container" data-control-name="address-inline">
       <Input

--- a/addon/components/utils/address-inline.hbs
+++ b/addon/components/utils/address-inline.hbs
@@ -1,11 +1,11 @@
 <div class="fx-col fx-gap-px-6 fx-1" ...attributes>
   {{#if this.useGoogleAutocomplete}}
-    <div class="fx-col fx-1 google-autocomplete-input-container" data-control-name="address-inline">
-      <Input
-        {{on "keyup" (fn this.onChange @value.address)}}
+    <div class="fx-col fx-1 google-autocomplete-input-container">
+      <OSS::InputContainer
+        @onChange={{this.onChange}}
         @value={{@value.address}}
-        class="upf-input"
         {{did-insert this.initAutoCompletion}}
+        data-control-name="address-inline"
       />
     </div>
   {{else}}

--- a/addon/components/utils/address-inline.hbs
+++ b/addon/components/utils/address-inline.hbs
@@ -1,0 +1,20 @@
+<div class="fx-col fx-gap-px-6 fx-1">
+  {{@value.address}}
+  <span class="font-color-gray-500">
+    {{t "upf_utils.address_inline"}}
+  </span>
+  {{#if this.useGoogleAutocomplete}}
+    <div class="fx-col fx-1 google-autocomplete-input-container" data-control-name="address-inline">
+      <Input
+        {{on "keyup" (fn this.onChange @value.address)}}
+        @value={{@value.address}}
+        class="upf-input"
+        {{did-insert this.initAutoCompletion}}
+      />
+    </div>
+  {{else}}
+    <div class="fx-col fx-1">
+      <OSS::InputContainer @value={{@value.address}} @onChange={{this.onChange}} data-control-name="address-inline" />
+    </div>
+  {{/if}}
+</div>

--- a/addon/components/utils/address-inline.ts
+++ b/addon/components/utils/address-inline.ts
@@ -6,19 +6,21 @@ import { getOwner } from '@ember/application';
 import { Loader } from '@googlemaps/js-api-loader';
 
 interface UtilsAddressInlineArgs {
-  value: {
-    address: string;
-    resolved_address: {
-      line_1: string;
-      zipcode: string;
-      city: string;
-      state?: string;
-      country_code: string;
-    };
-  };
+  value: ShippingAddress;
   useGoogleAutocomplete?: boolean;
   onChange(address: any): void;
 }
+
+export type ShippingAddress = {
+  address: string;
+  resolved_address: {
+    line_1: string;
+    zipcode: string;
+    city: string;
+    state?: string;
+    country_code: string;
+  } | null;
+};
 
 type GAddressComponent = google.maps.GeocoderAddressComponent;
 type GAutoComplete = google.maps.places.Autocomplete;

--- a/addon/components/utils/address-inline.ts
+++ b/addon/components/utils/address-inline.ts
@@ -1,0 +1,131 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { isTesting } from '@embroider/macros';
+import { getOwner } from '@ember/application';
+
+import { Loader } from '@googlemaps/js-api-loader';
+
+interface UtilsAddressInlineArgs {
+  value: {
+    address: string;
+    resolved_address: {
+      line_1: string;
+      zipcode: string;
+      city: string;
+      state?: string;
+      country_code: string;
+    };
+  };
+  useGoogleAutocomplete?: boolean;
+  onChange(address: any): void;
+}
+
+type GAddressComponent = google.maps.GeocoderAddressComponent;
+type GAutoComplete = google.maps.places.Autocomplete;
+type GPlaceResult = google.maps.places.PlaceResult;
+
+export default class extends Component<UtilsAddressInlineArgs> {
+  get useGoogleAutocomplete(): boolean {
+    return this.args.useGoogleAutocomplete ?? true;
+  }
+
+  @action
+  initAutoCompletion(): void {
+    if (isTesting()) return;
+    this.appendContainerLocally();
+    const loader = new Loader({
+      apiKey: getOwner(this).resolveRegistration('config:environment').google_map_api_key,
+      version: 'weekly'
+    });
+
+    loader.importLibrary('places').then(({ Autocomplete }) => {
+      const input = document.querySelector('[data-control-name="address-inline"] input') as HTMLInputElement;
+      const options = {
+        fields: ['address_components'],
+        strictBounds: false,
+        types: ['address']
+      };
+      const autocomplete = new Autocomplete(input, options);
+      this.initInputListeners(autocomplete, input);
+    });
+  }
+
+  @action
+  onChange(value: string): void {
+    this.args.onChange({ address: value, resolved_address: null });
+  }
+
+  private appendContainerLocally(): void {
+    const observer = new MutationObserver((mutationList: any) => {
+      for (const mutation of mutationList) {
+        if (mutation.type === 'childList') {
+          const pacContainer = mutation.addedNodes[0];
+          if (!pacContainer?.classList.contains('pac-container')) return;
+
+          document.querySelector('[data-control-name="address-inline"]')?.append(pacContainer);
+          observer.disconnect();
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true });
+  }
+
+  private initInputListeners(autocomplete: GAutoComplete, input: HTMLInputElement): void {
+    autocomplete.addListener('place_changed', () => {
+      const place = autocomplete.getPlace();
+      this.updateAddress(place, input);
+    });
+  }
+
+  private updateAddress(place: GPlaceResult, input: HTMLInputElement): void {
+    let address1: string = '';
+    let zipcode: string = '';
+    let city: string = '';
+    let state: string = '';
+    let country: string = '';
+
+    const mapper: { [key: string]: (comp: GAddressComponent) => void } = {
+      street_number: (comp) => {
+        address1 = `${comp.long_name} ${address1}`;
+      },
+      route: (comp) => {
+        address1 += comp.long_name;
+      },
+      postal_code: (comp) => {
+        zipcode = `${comp.long_name}${zipcode}`;
+      },
+      postal_code_suffix: (comp) => {
+        zipcode = `${zipcode}-${comp.long_name}`;
+      },
+      locality: (comp) => {
+        city = comp.long_name;
+      },
+      postal_town: (comp) => {
+        city = comp.long_name;
+      },
+      administrative_area_level_1: (comp) => {
+        state = comp.long_name ?? '';
+      },
+      country: (comp) => {
+        country = comp.short_name;
+      }
+    };
+
+    place.address_components!.reverse().map((component) => {
+      const componentType: string = component.types[0];
+
+      mapper[componentType]?.(component);
+    });
+
+    this.args.onChange({
+      address: input.value,
+      resolved_address: {
+        line_1: address1,
+        zipcode,
+        city,
+        state,
+        country_code: country
+      }
+    });
+  }
+}

--- a/app/components/utils/address-inline.js
+++ b/app/components/utils/address-inline.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/ember-upf-utils/components/utils/address-inline';

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -18,6 +18,7 @@ export default class ApplicationController extends Controller {
     countryCode: 'US',
     zipcode: '10016'
   };
+  @tracked shippingAddress = { address: '69 Avenue Victor Hugo, Paris, France', resolved_address: null };
 
   constructor() {
     super(...arguments);
@@ -38,5 +39,10 @@ export default class ApplicationController extends Controller {
   onLogoChange(icon, color) {
     this.selectedColor = color;
     this.selectedIcon = icon;
+  }
+
+  @action
+  onChangeAddress(value) {
+    this.shippingAddress = value;
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,18 +1,23 @@
-<div class='fx-col fx-gap-px-12 margin-px-30'>
+<div class="fx-col fx-gap-px-12 margin-px-30">
   <Utils::AddressForm
     @address={{this.address}}
     @usePhoneNumberInput={{false}}
     @hideNameAttrs={{false}}
     @useGoogleAutocomplete={{true}}
     @onChange={{this.onChange}}
-    @addressKey='line'
+    @addressKey="line"
   />
   <Utils::SocialMediaHandle
-    @handle='nomad.technologies'
-    @socialNetwork='instagram'
-    @errorMessage='This is an error'
+    @handle="nomad.technologies"
+    @socialNetwork="instagram"
+    @errorMessage="This is an error"
     @onChange={{this.onSocialMediaHandlerChanged}}
     @selectorOnly={{false}}
   />
   <LogoMaker @icon={{this.selectedIcon}} @color={{this.selectedColor}} @onChange={{this.onLogoChange}} />
+  <Utils::AddressInline
+    @value={{this.shippingAddress}}
+    @onChange={{this.onChangeAddress}}
+    @useGoogleAutocomplete={{true}}
+  />
 </div>

--- a/tests/integration/components/utils/address-inline-test.ts
+++ b/tests/integration/components/utils/address-inline-test.ts
@@ -51,6 +51,6 @@ module('Integration | Component | utils/address-inline', function (hooks) {
       hbs`<Utils::AddressInline @value={{this.address}} @useGoogleAutocomplete={{true}}
                               @onChange={{this.onChange}} />`
     );
-    assert.dom('.google-autocomplete-input-container[data-control-name="address-inline"]').exists();
+    assert.dom('.google-autocomplete-input-container [data-control-name="address-inline"]').exists();
   });
 });

--- a/tests/integration/components/utils/address-inline-test.ts
+++ b/tests/integration/components/utils/address-inline-test.ts
@@ -1,0 +1,56 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
+import EmberObject from '@ember/object';
+import { render, typeIn } from '@ember/test-helpers';
+import sinon from 'sinon';
+
+module('Integration | Component | utils/address-inline', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(function () {
+    this.address = EmberObject.create({
+      address: '123 Main St',
+      resolved_address: null
+    });
+    this.onChange = sinon.stub();
+  });
+
+  module('when @useGoogleAutocomplete is false', () => {
+    test('It renders', async function (assert) {
+      await render(
+        hbs`<Utils::AddressInline @value={{this.address}} @useGoogleAutocomplete={{false}}
+                              @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-inline"]').exists();
+    });
+
+    test('It renders the correct address', async function (assert) {
+      await render(
+        hbs`<Utils::AddressInline @value={{this.address}} @useGoogleAutocomplete={{false}}
+                              @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-inline"] .upf-input').hasValue('123 Main St');
+    });
+
+    test('when type in value, it calls the @onChange', async function (assert) {
+      await render(
+        hbs`<Utils::AddressInline @value={{this.address}} @useGoogleAutocomplete={{false}}
+                              @onChange={{this.onChange}} />`
+      );
+      await typeIn('[data-control-name="address-inline"] .upf-input', 'reet', { delay: 0 });
+      assert.equal(this.onChange.callCount, 4);
+      assert.true(this.onChange.lastCall.calledWith({ address: '123 Main Street', resolved_address: null }));
+    });
+  });
+
+  test('when @useGoogleAutocomplete is true, it renders the google autocomplete input', async function (assert) {
+    await render(
+      hbs`<Utils::AddressInline @value={{this.address}} @useGoogleAutocomplete={{true}}
+                              @onChange={{this.onChange}} />`
+    );
+    assert.dom('.google-autocomplete-input-container[data-control-name="address-inline"]').exists();
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,5 +1,4 @@
 upf_utils:
-  address_inline: Address
   address_form:
     first_name: First Name*
     last_name: Last Name*

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,4 +1,5 @@
 upf_utils:
+  address_inline: Address
   address_form:
     first_name: First Name*
     last_name: Last Name*


### PR DESCRIPTION
### What does this PR do?

Create new address inline with Google place API. This component is inspired by the `Utils::AddressForm` component

### What are the observable changes?

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
