### PR TITLE
[ember-upf-utils] Removed deprecated @placeholder argument on Input

### DIFF
--- a/addon/components/u-edit/shared-triggers/modals/file-uploader.hbs
+++ b/addon/components/u-edit/shared-triggers/modals/file-uploader.hbs
@@ -1,16 +1,24 @@
 <OSS::ModalDialog
- @title={{t (concat "uedit_editor.toolbar." this.titleKey ".title")}} @close={{@closeAction}} class="uedit-file-uploader">
+  @title={{t (concat "uedit_editor.toolbar." this.titleKey ".title")}}
+  @close={{@closeAction}}
+  class="uedit-file-uploader"
+>
   <:content>
     {{#if (eq this.titleKey "pdf")}}
       <div class="form-group">
-        <OSS::Alert @title={{t "uedit_editor.toolbar.pdf.alert.title"}} @subtitle={{t "uedit_editor.toolbar.pdf.alert.subtitle"}} />
+        <OSS::Alert
+          @title={{t "uedit_editor.toolbar.pdf.alert.title"}}
+          @subtitle={{t "uedit_editor.toolbar.pdf.alert.subtitle"}}
+        />
       </div>
     {{/if}}
     <div class="form-group">
       <label>{{t (concat "uedit_editor.toolbar.by_url")}}</label>
       <Input
-       @value={{this.directURL}} @placeholder={{t (concat "uedit_editor.toolbar." this.titleKey ".placeholder")}}
-       class="form-control upf-input" />
+        @value={{this.directURL}}
+        placeholder={{t (concat "uedit_editor.toolbar." this.titleKey ".placeholder")}}
+        class="form-control upf-input"
+      />
     </div>
 
     <OSS::UploadArea
@@ -29,9 +37,11 @@
     <div class="fx-row fx-1 fx-malign-end fx-gap-px-10">
       <OSS::Button @label={{t (concat "uedit_editor.toolbar.cancel")}} {{on "click" @closeAction}} />
       <OSS::Button
-        @skin="primary" @label={{t (concat "uedit_editor.toolbar." this.titleKey ".title")}}
+        @skin="primary"
+        @label={{t (concat "uedit_editor.toolbar." this.titleKey ".title")}}
         disabled={{and (not this.fileURL) (not this.directURL)}}
-        {{on "click" this.addFile}} />
+        {{on "click" this.addFile}}
+      />
     </div>
   </:footer>
 </OSS::ModalDialog>

--- a/addon/components/utils/address-form.hbs
+++ b/addon/components/utils/address-form.hbs
@@ -9,7 +9,8 @@
           @value={{@address.firstName}}
           @onChange={{fn this.onFieldUpdate "firstName"}}
           @placeholder={{t "upf_utils.address_form.placeholder.first_name"}}
-          data-control-name="address-form-first-name" />
+          data-control-name="address-form-first-name"
+        />
       </div>
 
       <div class="fx-col fx-gap-px-6 fx-1">
@@ -20,7 +21,8 @@
           @value={{@address.lastName}}
           @onChange={{fn this.onFieldUpdate "lastName"}}
           @placeholder={{t "upf_utils.address_form.placeholder.last_name"}}
-          data-control-name="address-form-last-name" />
+          data-control-name="address-form-last-name"
+        />
       </div>
     </div>
   {{/unless}}
@@ -36,10 +38,14 @@
           @number={{this.phoneNumber}}
           @onChange={{this.onPhoneNumberUpdate}}
           @validates={{this.onPhoneNumberValidation}}
-          data-control-name="address-form-phone" />
+          data-control-name="address-form-phone"
+        />
       {{else}}
-        <OSS::InputContainer @value={{@address.phone}} @placeholder={{t "upf_utils.address_form.placeholder.phone"}}
-                             data-control-name="address-form-phone" />
+        <OSS::InputContainer
+          @value={{@address.phone}}
+          @placeholder={{t "upf_utils.address_form.placeholder.phone"}}
+          data-control-name="address-form-phone"
+        />
       {{/if}}
     </div>
   {{/unless}}
@@ -50,15 +56,21 @@
     </span>
     {{#if this.useGoogleAutocomplete}}
       <div class="fx-col google-autocomplete-input-container" data-control-name="address-form-address1">
-        <Input @value={{get @address (concat this.addressKey "1")}} class="upf-input" {{on "keyup" (fn this.onFieldUpdate (concat this.addressKey "1"))}}
-               @placeholder={{t "upf_utils.address_form.placeholder.line1"}} {{did-insert this.initAutoCompletion}} />
+        <Input
+          @value={{get @address (concat this.addressKey "1")}}
+          class="upf-input"
+          {{on "keyup" (fn this.onFieldUpdate (concat this.addressKey "1"))}}
+          placeholder={{t "upf_utils.address_form.placeholder.line1"}}
+          {{did-insert this.initAutoCompletion}}
+        />
       </div>
     {{else}}
       <OSS::InputContainer
         @value={{get @address (concat this.addressKey "1")}}
         @onChange={{fn this.onFieldUpdate (concat this.addressKey "1")}}
         @placeholder={{t "upf_utils.address_form.placeholder.line1"}}
-        data-control-name="address-form-address1" />
+        data-control-name="address-form-address1"
+      />
     {{/if}}
   </div>
 
@@ -70,7 +82,8 @@
       @value={{get @address (concat this.addressKey "2")}}
       @onChange={{fn this.onFieldUpdate (concat this.addressKey "2")}}
       @placeholder={{t "upf_utils.address_form.placeholder.line2"}}
-      data-control-name="address-form-address2" />
+      data-control-name="address-form-address2"
+    />
   </div>
 
   <div class="fx-row fx-gap-px-12">
@@ -78,8 +91,12 @@
       <span class="font-size-md font-color-gray-500">
         {{t "upf_utils.address_form.country"}}
       </span>
-      <OSS::CountrySelector @sourceList={{this.countries}} @onChange={{this.applyCountry}}
-                            @value={{@address.countryCode}} data-control-name="address-form-country" />
+      <OSS::CountrySelector
+        @sourceList={{this.countries}}
+        @onChange={{this.applyCountry}}
+        @value={{@address.countryCode}}
+        data-control-name="address-form-country"
+      />
     </div>
 
     <div class="fx-col fx-gap-px-6 fx-1">
@@ -88,15 +105,19 @@
         {{#if this.provincesForCountry}}*{{/if}}
       </span>
       {{#if this.provincesForCountry}}
-        <OSS::ProvinceSelector @value={{@address.state}} @sourceList={{this.provincesForCountry}}
-                               @onChange={{this.applyProvince}}
-                               data-control-name="address-form-state" />
+        <OSS::ProvinceSelector
+          @value={{@address.state}}
+          @sourceList={{this.provincesForCountry}}
+          @onChange={{this.applyProvince}}
+          data-control-name="address-form-state"
+        />
       {{else}}
         <OSS::InputContainer
           @value={{@address.state}}
           @onChange={{fn this.onFieldUpdate "state"}}
           @placeholder={{t "upf_utils.address_form.placeholder.state"}}
-          data-control-name="address-form-state" />
+          data-control-name="address-form-state"
+        />
       {{/if}}
     </div>
   </div>
@@ -110,7 +131,8 @@
         @value={{@address.city}}
         @onChange={{fn this.onFieldUpdate "city"}}
         @placeholder={{t "upf_utils.address_form.placeholder.city"}}
-        data-control-name="address-form-city" />
+        data-control-name="address-form-city"
+      />
     </div>
 
     <div class="fx-col fx-gap-px-6 fx-1">
@@ -121,7 +143,8 @@
         @value={{@address.zipcode}}
         @onChange={{fn this.onFieldUpdate "zipcode"}}
         @placeholder={{t "upf_utils.address_form.placeholder.postal_code"}}
-        data-control-name="address-form-zipcode" />
+        data-control-name="address-form-zipcode"
+      />
     </div>
   </div>
 </div>

--- a/addon/components/utils/social-media-handle.hbs
+++ b/addon/components/utils/social-media-handle.hbs
@@ -1,12 +1,18 @@
 <div class="social-handle-container fx-col fx-1" ...attributes>
-  <div class="social-handle-input upf-input fx-row fx-1 fx-xalign-center
-                {{if @errorMessage 'social-handle-input--error'}}">
-    <div class="{{if @selectorOnly 'selector-full-width'}} selector
-                fx-row fx-gap-px-12 fx-malign-space-between"
-         role="button" {{on "click" this.toggleSelector}}>
+  <div
+    class="social-handle-input upf-input fx-row fx-1 fx-xalign-center {{if @errorMessage 'social-handle-input--error'}}"
+  >
+    <div
+      class="{{if @selectorOnly 'selector-full-width'}} selector fx-row fx-gap-px-12 fx-malign-space-between"
+      role="button"
+      {{on "click" this.toggleSelector}}
+    >
       <div class="fx-row fx-xalign-center fx-gap-px-12">
         <OSS::Icon
-				  @style="brand" @icon={{get this.socialMediaIcons this.selectedNetwork.name}} class="font-color-{{this.selectedNetwork.name}}-500" />
+          @style="brand"
+          @icon={{get this.socialMediaIcons this.selectedNetwork.name}}
+          class="font-color-{{this.selectedNetwork.name}}-500"
+        />
 
         {{#if @selectorOnly}}
           <span>{{t (concat "upf_utils.social_media_handle.networks." this.selectedNetwork.name)}}</span>
@@ -15,20 +21,34 @@
       <OSS::Icon @icon={{if this.selectorShown "fa-chevron-up" "fa-chevron-down"}} />
     </div>
     {{#unless @selectorOnly}}
-      <Input class="fx-1" type="text" @value={{this.handle}} autocomplete="off"
-             @placeholder={{t "upf_utils.social_media_handle.input_placeholder"}}
-             {{on "blur" this.onBlur}} {{on "keydown" this.checkEnterKey}} />
+      <Input
+        class="fx-1"
+        type="text"
+        @value={{this.handle}}
+        autocomplete="off"
+        placeholder={{t "upf_utils.social_media_handle.input_placeholder"}}
+        {{on "blur" this.onBlur}}
+        {{on "keydown" this.checkEnterKey}}
+      />
     {{/unless}}
   </div>
   {{#if this.selectorShown}}
-    <OSS::InfiniteSelect @items={{this.socialMediaNetworks}} @searchEnabled={{false}}
-                         @onSelect={{this.onSelect}}
-                         {{on-click-outside this.hideSelector}}>
+    <OSS::InfiniteSelect
+      @items={{this.socialMediaNetworks}}
+      @searchEnabled={{false}}
+      @onSelect={{this.onSelect}}
+      {{on-click-outside this.hideSelector}}
+    >
       <:option as |network|>
-        <div class="fx-row fx-xalign-center fx-gap-px-9 margin-left-px-6
-                    {{if (eq this.selectedNetwork network) 'row-selected'}}">
-					<OSS::Icon
-						@style="brand" @icon={{get this.socialMediaIcons network.name}} class="font-color-{{network.name}}-500" />
+        <div
+          class="fx-row fx-xalign-center fx-gap-px-9 margin-left-px-6
+            {{if (eq this.selectedNetwork network) 'row-selected'}}"
+        >
+          <OSS::Icon
+            @style="brand"
+            @icon={{get this.socialMediaIcons network.name}}
+            class="font-color-{{network.name}}-500"
+          />
           <span class="symbol text-color-default-light fx-1">
             {{t (concat "upf_utils.social_media_handle.networks." network.name)}}
           </span>


### PR DESCRIPTION
### What does this PR do?

Removed "@" on placeholder argument on Input components, as this is now deprecated.
Also, Prettier.

<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[VEL-4671](https://linear.app/upfluence/issue/VEL-4671/httpsdeprecationsemberjscomv3xtoc-ember-built-in-components-legacy)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
