### PR TITLE
Improve the utm-builder by removing the variablesEnabled args

### DIFF
--- a/addon/components/utils/utm-link-builder.hbs
+++ b/addon/components/utils/utm-link-builder.hbs
@@ -9,7 +9,7 @@
 >
   <:contents>
     <div class="activated-utms fx-col fx-1 fx-gap-px-12">
-      {{#if @variablesEnabled}}
+      {{#if this.variablesEnabled}}
         <Utils::TemplatedInputGroup
           @title={{t "utms.fields.source"}}
           @variables={{@variables}}

--- a/addon/components/utils/utm-link-builder.ts
+++ b/addon/components/utils/utm-link-builder.ts
@@ -20,7 +20,6 @@ interface UtilsUtmLinkBuilderArgs {
   title?: string;
   subtitle?: string;
   displayPreview?: boolean;
-  variablesEnabled?: boolean;
   variables?: Record<string, string>;
   onChange(url: string, utmsEnabled: boolean, formValid: boolean, utmFields: UtmFields): void;
 }
@@ -33,6 +32,10 @@ export default class UtilsUtmLinkBuilder extends Component<UtilsUtmLinkBuilderAr
   @tracked utmMedium: string = '';
   @tracked utmCampaign: string = '';
   @tracked validationErrors: Record<string, FeedbackMessage> = {};
+
+  get variablesEnabled(): boolean {
+    return Boolean(this.args.variables);
+  }
 
   get utmsValid(): boolean {
     return ![this.utmSource, this.utmMedium, this.utmCampaign].some((field) => isBlank(field));

--- a/tests/integration/components/utils/utm-link-builder-test.ts
+++ b/tests/integration/components/utils/utm-link-builder-test.ts
@@ -104,12 +104,18 @@ module('Integration | Component | utils/utm-link-builder', function (hooks) {
     });
   });
 
+  test('If variables are unenabled, templated input group component is not rendered', async function (assert) {
+    this.variables = ['InstagramUsername', 'TiktokUsername'];
+
+    await render(hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} />`);
+    await click('.upf-toggle');
+    assert.dom('[data-control-name="templated-input-group-insert-variable-link"]').doesNotExist();
+  });
+
   test('If variables are enabled, templated input group component is rendered', async function (assert) {
     this.variables = ['InstagramUsername', 'TiktokUsername'];
 
-    await render(
-      hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} @variablesEnabled={{true}} @variables={{this.variables}}/>`
-    );
+    await render(hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} @variables={{this.variables}} />`);
     await click('.upf-toggle');
     assert
       .dom('[data-control-name="templated-input-group-insert-variable-link"]')
@@ -120,9 +126,7 @@ module('Integration | Component | utils/utm-link-builder', function (hooks) {
   test('If variables are enabled and a space character is inputed, it is replaced with a + sign', async function (assert) {
     this.variables = ['InstagramUsername', 'TiktokUsername'];
 
-    await render(
-      hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} @variablesEnabled={{true}} @variables={{this.variables}} />`
-    );
+    await render(hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} @variables={{this.variables}} />`);
     await click('.upf-toggle');
 
     await typeIn('[data-control-name="utm_source_input"] .upf-input', 'a a', { delay: 0 });


### PR DESCRIPTION
### What does this PR do?

Improve the utm-builder by removing the variablesEnabled args

### What are the observable changes?

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
