### PR TITLE
Fix insert variable link

### DIFF
--- a/addon/components/utils/templated-input-group.hbs
+++ b/addon/components/utils/templated-input-group.hbs
@@ -8,7 +8,8 @@
         @icon="fa-plus"
         @label={{t "upf_utils.templated_input_group.insert_variable"}}
         {{on "mousedown" this.preventBlur}}
-        {{on "click" this.openTemplateVariables}}
+        {{on "click" this.toggleTemplateVariables}}
+        {{did-insert this.registerInsertVariableLink}}
         data-control-name="templated-input-group-insert-variable-link"
       />
       <div

--- a/addon/components/utils/templated-input-group.ts
+++ b/addon/components/utils/templated-input-group.ts
@@ -24,6 +24,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   @tracked displayTemplateVariables = false;
   @tracked _inputValue = '';
   @tracked inputElement?: HTMLInputElement | null;
+  @tracked insertVariableLink?: HTMLElement | null;
 
   get inputValue(): string {
     return this.args.value;
@@ -86,7 +87,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
     }
 
     this.inputElement?.focus();
-    this.closeTemplateVariables();
+    this.displayTemplateVariables = false;
   }
 
   @action
@@ -98,20 +99,33 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   }
 
   @action
-  openTemplateVariables(e: MouseEvent): void {
+  toggleTemplateVariables(e: MouseEvent): void {
     e.stopPropagation();
     e.preventDefault();
-    this.displayTemplateVariables = true;
+    this.displayTemplateVariables = !this.displayTemplateVariables;
   }
 
   @action
-  closeTemplateVariables(): void {
+  closeTemplateVariables(_: HTMLElement, e: MouseEvent): void {
+    if (!this.displayTemplateVariables) return;
+    const isTargetTriggered =
+      this.insertVariableLink &&
+      (this.insertVariableLink === e.target || this.insertVariableLink.contains(e.target as HTMLElement));
+    if (isTargetTriggered) {
+      this.toggleTemplateVariables(e);
+      return;
+    }
     this.displayTemplateVariables = false;
   }
 
   @action
   registerInput(e: HTMLElement): void {
     this.inputElement = e.querySelector('input');
+  }
+
+  @action
+  registerInsertVariableLink(el: HTMLElement): void {
+    this.insertVariableLink = el;
   }
 
   preventBlur(e: MouseEvent): void {


### PR DESCRIPTION
### What does this PR do?
UTM variables dropdown could not be closed by clicking again on the insert variables link. This PR fixes the issue
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?

https://github.com/user-attachments/assets/9c03c6bc-bfa5-44a6-a8c7-e1fd9cc30a35


<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
