### PR TITLE
Fix templated input group offset dropdown

### DIFF
--- a/addon/components/utils/templated-input-group.hbs
+++ b/addon/components/utils/templated-input-group.hbs
@@ -1,4 +1,4 @@
-<div class="fx-col fx-gap-px-6" ...attributes>
+<div class="templated-input-group" ...attributes>
   <div class="fx-col fx-gap-px-3">
     <div class="fx-row fx-malign-space-between">
       <div class="font-color-gray-500 font-size-md" data-control-name="templated-input-group-title">

--- a/addon/components/utils/templated-input-group.hbs
+++ b/addon/components/utils/templated-input-group.hbs
@@ -2,7 +2,10 @@
   <div class="fx-col fx-gap-px-3">
     <div class="fx-row fx-malign-space-between">
       <div class="font-color-gray-500 font-size-md">
-        <span>{{@title}}</span>{{#if @required}}<span class="font-color-error-500">*</span>{{/if}}
+        <span>{{@title}}</span>
+        {{#if @required}}
+          <span class="font-color-error-500">*</span>
+        {{/if}}
       </div>
       <OSS::Link
         @icon="fa-plus"
@@ -12,13 +15,14 @@
         data-control-name="templated-input-group-insert-variable-link"
       />
       <div
-        class="upf-floating-menu upf-floating-menu--{{if this.displayTemplateVariables 'visible' 'hidden'}}"
+        class="upf-floating-menu upf-floating-menu--{{if this.displayTemplateVariables 'visible' 'hidden'}}
+          upf-floating-menu--skip-offset"
         {{on-click-outside this.closeTemplateVariables useCapture=true}}
         {{attach-element
           to=this.inputElement
           placement="bottom-start"
           fallbackPlacements=(array "top-start")
-          offset=0
+          offset=12
           width="300"
         }}
       >
@@ -38,15 +42,13 @@
     </div>
     <span class="font-color-gray-500 text-size-4">{{@subtitle}}</span>
   </div>
-  <div class="input-container">
-    <OSS::InputContainer
-      @value={{this.inputValue}}
-      @placeholder={{@placeholder}}
-      @onChange={{this.onInput}}
-      @feedbackMessage={{this.feedbackMessage}}
-      {{on "keyup" this.triggerVariableInput}}
-      {{did-insert this.registerInput}}
-      data-control-name="templated-input-group-input-container"
-    />
-  </div>
+  <OSS::InputContainer
+    @value={{this.inputValue}}
+    @placeholder={{@placeholder}}
+    @onChange={{this.onInput}}
+    @feedbackMessage={{this.feedbackMessage}}
+    {{on "keyup" this.triggerVariableInput}}
+    {{did-insert this.registerInput}}
+    data-control-name="templated-input-group-input-container"
+  />
 </div>

--- a/addon/components/utils/templated-input-group.hbs
+++ b/addon/components/utils/templated-input-group.hbs
@@ -1,7 +1,7 @@
 <div class="fx-col fx-gap-px-6" ...attributes>
   <div class="fx-col fx-gap-px-3">
     <div class="fx-row fx-malign-space-between">
-      <div class="font-color-gray-500 font-size-md">
+      <div class="font-color-gray-500 font-size-md" data-control-name="templated-input-group-title">
         <span>{{@title}}</span>
         {{#if @required}}
           <span class="font-color-error-500">*</span>
@@ -40,7 +40,9 @@
         {{/each}}
       </div>
     </div>
-    <span class="font-color-gray-500 text-size-4">{{@subtitle}}</span>
+    <span class="font-color-gray-500 text-size-4" data-control-name="templated-input-group-subtitle">
+      {{@subtitle}}
+    </span>
   </div>
   <OSS::InputContainer
     @value={{this.inputValue}}

--- a/app/styles/components/utils/templated-imput-group.less
+++ b/app/styles/components/utils/templated-imput-group.less
@@ -1,0 +1,9 @@
+.templated-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-px-6);
+
+  .upf-floating-menu--skip-offset {
+    margin-top: 0;
+  }
+}

--- a/app/styles/upf-utils.less
+++ b/app/styles/upf-utils.less
@@ -13,6 +13,7 @@
 @import 'components/utils/social-media-handler';
 @import 'components/utils/product-row';
 @import 'components/utils/address-form';
+@import 'components/utils/templated-imput-group';
 @import 'vendors/flatpickr';
 
 @import 'layout/side-hover-panel/styles';

--- a/tests/integration/components/utils/templated-input-group-test.ts
+++ b/tests/integration/components/utils/templated-input-group-test.ts
@@ -21,49 +21,43 @@ module('Integration | Component | utils/templated-input-group', function (hooks)
   module('Component rendering', () => {
     test('It renders with minimum parameters', async function (assert) {
       await render(
-        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} data-control-name="templated-input" />`
+        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} />`
       );
 
-      assert.dom('[data-control-name="templated-input"]').exists();
       assert.dom('[data-control-name="templated-input-group-insert-variable-link"]').exists();
       assert
         .dom('[data-control-name="templated-input-group-insert-variable-link"]')
         .hasText(this.intl.t('upf_utils.templated_input_group.insert_variable'));
       assert.dom('[data-control-name="templated-input-group-input-container"]').exists();
-      assert.dom('[data-control-name="templated-input"] input').doesNotHaveAttribute('placeholder');
+      assert.dom('input').doesNotHaveAttribute('placeholder');
     });
 
     test('Not required field title is properly displayed', async function (assert) {
       await render(
-        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} data-control-name="templated-input"/>`
+        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} />`
       );
-
-      assert.dom('[data-control-name="templated-input"]').containsText('Title');
-      assert.dom('[data-control-name="templated-input"]').doesNotContainText('*');
+      assert.dom('[data-control-name="templated-input-group-title"]').hasText('Title');
     });
 
     test('Required field title is properly displayed', async function (assert) {
       await render(
-        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} data-control-name="templated-input"/>`
+        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} />`
       );
-
-      assert.dom('[data-control-name="templated-input"]').containsText('Title*');
+      assert.dom('[data-control-name="templated-input-group-title"]').hasText('Title *');
     });
 
     test('Subtitle is displayed', async function (assert) {
       await render(
-        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @subtitle={{this.subtitle}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} data-control-name="templated-input"/>`
+        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @subtitle={{this.subtitle}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} />`
       );
-
-      assert.dom('[data-control-name="templated-input"]').containsText('Subtitle');
+      assert.dom('[data-control-name="templated-input-group-subtitle"]').containsText('Subtitle');
     });
 
     test('Placeholder is displayed', async function (assert) {
       await render(
-        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @subtitle={{this.subtitle}} @placeholder={{this.placeholder}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} data-control-name="templated-input"/>`
+        hbs`<Utils::TemplatedInputGroup @title={{this.title}} @subtitle={{this.subtitle}} @placeholder={{this.placeholder}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} />`
       );
-
-      assert.dom('[data-control-name="templated-input"] input').hasProperty('placeholder', 'Placeholder');
+      assert.dom('input').hasProperty('placeholder', 'Placeholder');
     });
   });
 

--- a/tests/integration/components/utils/templated-input-group-test.ts
+++ b/tests/integration/components/utils/templated-input-group-test.ts
@@ -18,6 +18,13 @@ module('Integration | Component | utils/templated-input-group', function (hooks)
     this.onChange = sinon.spy();
   });
 
+  test('It renders', async function (assert) {
+    await render(
+      hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} />`
+    );
+    assert.dom('.templated-input-group').exists();
+  });
+
   module('Component rendering', () => {
     test('It renders with minimum parameters', async function (assert) {
       await render(


### PR DESCRIPTION
### What does this PR do?

Fix templated input group offset dropdown

### What are the observable changes?

![Peek 2025-05-05 16-14](https://github.com/user-attachments/assets/7451e183-5f35-4fae-9eec-364205819ff7)

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
