### PR TITLE
Added: Ability to focus AddressForm component inputs from parent

### DIFF
--- a/addon/components/utils/address-form.hbs
+++ b/addon/components/utils/address-form.hbs
@@ -10,6 +10,7 @@
           @onChange={{fn this.onFieldUpdate "firstName"}}
           @placeholder={{t "upf_utils.address_form.placeholder.first_name"}}
           data-control-name="address-form-first-name"
+          {{(if (eq @focus "first-name") (modifier "enable-input-autofocus"))}}
         />
       </div>
 
@@ -22,6 +23,7 @@
           @onChange={{fn this.onFieldUpdate "lastName"}}
           @placeholder={{t "upf_utils.address_form.placeholder.last_name"}}
           data-control-name="address-form-last-name"
+          {{(if (eq @focus "last-name") (modifier "enable-input-autofocus"))}}
         />
       </div>
     </div>
@@ -39,12 +41,14 @@
           @onChange={{this.onPhoneNumberUpdate}}
           @validates={{this.onPhoneNumberValidation}}
           data-control-name="address-form-phone"
+          {{(if (eq @focus "phone") (modifier "enable-input-autofocus"))}}
         />
       {{else}}
         <OSS::InputContainer
           @value={{@address.phone}}
           @placeholder={{t "upf_utils.address_form.placeholder.phone"}}
           data-control-name="address-form-phone"
+          {{(if (eq @focus "phone") (modifier "enable-input-autofocus"))}}
         />
       {{/if}}
     </div>
@@ -62,6 +66,7 @@
           {{on "keyup" (fn this.onFieldUpdate (concat this.addressKey "1"))}}
           placeholder={{t "upf_utils.address_form.placeholder.line1"}}
           {{did-insert this.initAutoCompletion}}
+          {{(if (eq @focus "line1") (modifier "enable-input-autofocus"))}}
         />
       </div>
     {{else}}
@@ -70,6 +75,7 @@
         @onChange={{fn this.onFieldUpdate (concat this.addressKey "1")}}
         @placeholder={{t "upf_utils.address_form.placeholder.line1"}}
         data-control-name="address-form-address1"
+        {{(if (eq @focus "line1") (modifier "enable-input-autofocus"))}}
       />
     {{/if}}
   </div>
@@ -83,6 +89,7 @@
       @onChange={{fn this.onFieldUpdate (concat this.addressKey "2")}}
       @placeholder={{t "upf_utils.address_form.placeholder.line2"}}
       data-control-name="address-form-address2"
+      {{(if (eq @focus "line2") (modifier "enable-input-autofocus"))}}
     />
   </div>
 
@@ -110,6 +117,7 @@
           @sourceList={{this.provincesForCountry}}
           @onChange={{this.applyProvince}}
           data-control-name="address-form-state"
+          {{(if (eq @focus "state") (modifier "enable-input-autofocus"))}}
         />
       {{else}}
         <OSS::InputContainer
@@ -117,6 +125,7 @@
           @onChange={{fn this.onFieldUpdate "state"}}
           @placeholder={{t "upf_utils.address_form.placeholder.state"}}
           data-control-name="address-form-state"
+          {{(if (eq @focus "state") (modifier "enable-input-autofocus"))}}
         />
       {{/if}}
     </div>
@@ -132,6 +141,7 @@
         @onChange={{fn this.onFieldUpdate "city"}}
         @placeholder={{t "upf_utils.address_form.placeholder.city"}}
         data-control-name="address-form-city"
+        {{(if (eq @focus "city") (modifier "enable-input-autofocus"))}}
       />
     </div>
 
@@ -144,6 +154,7 @@
         @onChange={{fn this.onFieldUpdate "zipcode"}}
         @placeholder={{t "upf_utils.address_form.placeholder.postal_code"}}
         data-control-name="address-form-zipcode"
+        {{(if (eq @focus "zipcode") (modifier "enable-input-autofocus"))}}
       />
     </div>
   </div>

--- a/addon/components/utils/address-form.ts
+++ b/addon/components/utils/address-form.ts
@@ -235,12 +235,7 @@ export default class extends Component<UtilsAddressFormArgs> {
 
   private openCountrySelect(): void {
     next(() => {
-      const countryInput = document.querySelector(
-        '[data-control-name="address-form-country"] .upf-input'
-      ) as HTMLInputElement;
-      if (countryInput) {
-        countryInput.click();
-      }
+      (document.querySelector('[data-control-name="address-form-country"] .upf-input') as HTMLInputElement)?.click();
     });
   }
 }

--- a/addon/components/utils/address-form.ts
+++ b/addon/components/utils/address-form.ts
@@ -7,6 +7,18 @@ import { getOwner } from '@ember/application';
 
 import { Loader } from '@googlemaps/js-api-loader';
 import { CountryData, countries } from '@upfluence/oss-components/utils/country-codes';
+import { next } from '@ember/runloop';
+
+type FocusableInput =
+  | 'first-name'
+  | 'last-name'
+  | 'line1'
+  | 'line2'
+  | 'country'
+  | 'city'
+  | 'state'
+  | 'zipcode'
+  | 'phone';
 
 interface UtilsAddressFormArgs {
   address: any;
@@ -15,6 +27,7 @@ interface UtilsAddressFormArgs {
   hidePhoneNumber?: boolean;
   useGoogleAutocomplete?: boolean;
   addressKey?: AddressKey;
+  focus?: FocusableInput;
   onChange(address: any, isValid: boolean): void;
 }
 
@@ -41,6 +54,9 @@ export default class extends Component<UtilsAddressFormArgs> {
     super(owner, args);
     if (args.addressKey) this.addressKey = args.addressKey;
     this.validatedAddressFieldsHandler();
+    if (this.args.focus === 'country') {
+      this.openCountrySelect();
+    }
   }
 
   get useGoogleAutocomplete(): boolean {
@@ -215,5 +231,16 @@ export default class extends Component<UtilsAddressFormArgs> {
       }
     });
     observer.observe(document.body, { childList: true });
+  }
+
+  private openCountrySelect(): void {
+    next(() => {
+      const countryInput = document.querySelector(
+        '[data-control-name="address-form-country"] .upf-input'
+      ) as HTMLInputElement;
+      if (countryInput) {
+        countryInput.click();
+      }
+    });
   }
 }

--- a/tests/integration/components/utils/address-form-test.ts
+++ b/tests/integration/components/utils/address-form-test.ts
@@ -26,6 +26,85 @@ module('Integration | Component | utils/address-form', function (hooks) {
     this.onChange = sinon.stub();
   });
 
+  module('@focus paramter', (hooks) => {
+    hooks.beforeEach(function () {
+      this.address = EmberObject.create({
+        firstName: '',
+        lastName: '',
+        address1: '',
+        address2: '',
+        city: '',
+        state: '',
+        countryCode: '',
+        zipcode: '',
+        phone: ''
+      });
+    });
+
+    test('It focuses the first name input when @focus is set to first-name', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="first-name" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-first-name"] input').isFocused();
+    });
+
+    test('It focuses the last name input when @focus is set to last-name', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="last-name" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-last-name"] input').isFocused();
+    });
+
+    test('It focuses the address1 input when @focus is set to line1', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="line1" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-address1"] input').isFocused();
+    });
+
+    test('It focuses the address2 input when @focus is set to line2', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="line2" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-address2"] input').isFocused();
+    });
+
+    test('It focuses the city input when @focus is set to city', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="city" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-city"] input').isFocused();
+    });
+
+    test('It focuses the state input when @focus is set to state', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="state" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-state"] input').isFocused();
+    });
+
+    test('It focuses the zipcode input when @focus is set to zipcode', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="zipcode" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-zipcode"] input').isFocused();
+    });
+
+    test('It focuses the phone input when @focus is set to phone', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="phone" @onChange={{this.onChange}} />`
+      );
+      assert.dom('[data-control-name="address-form-phone"] input').isFocused();
+    });
+
+    test('it opens the country select when @focus is set to country', async function (assert) {
+      await render(
+        hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}} @focus="country" @onChange={{this.onChange}} />`
+      );
+      assert.dom('.upf-infinite-select').exists();
+    });
+  });
+
   test('It renders and calls the onChange action when setting up the component', async function (assert) {
     await render(
       hbs`<Utils::AddressForm @address={{this.address}} @useGoogleAutocomplete={{false}}


### PR DESCRIPTION
### What does this PR do?

Added: Ability to focus AddressForm component inputs from parent

Some screenshot examples from the side-panel:
![Screenshot 2025-05-15 at 16 02 00](https://github.com/user-attachments/assets/653602e9-323f-447a-97db-1e903021f805)
![Screenshot 2025-05-15 at 16 01 50](https://github.com/user-attachments/assets/1659047f-1be6-4228-a7e0-a606e92a7cb1)
![Screenshot 2025-05-15 at 16 01 42](https://github.com/user-attachments/assets/3ff40aea-8981-4b56-9061-7c560dc77875)
![Screenshot 2025-05-15 at 16 01 32](https://github.com/user-attachments/assets/6cf42090-fc1a-4bfc-b83a-d8bc705f0d93)


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled