### PR TITLE
Fixed jace blob image urls

### DIFF
--- a/addon/components/utils/jace-blob.hbs
+++ b/addon/components/utils/jace-blob.hbs
@@ -1,12 +1,12 @@
 <div class="jace-blob-container {{if @loading 'jace-blob-container--active'}}">
   <div class="jace-blob">
     <img
-      src="@upfluence/ember-upf-utils/assets/images/jace-blob-loading.gif"
+      src="/@upfluence/ember-upf-utils/assets/images/jace-blob-loading.gif"
       alt="jace-blob-loading"
       class={{this.loadingClass}}
     />
     <img
-      src="@upfluence/ember-upf-utils/assets/images/jace-blob-inactive.gif"
+      src="/@upfluence/ember-upf-utils/assets/images/jace-blob-inactive.gif"
       alt="jace-blob-inactive"
       class={{this.inactiveClass}}
     />


### PR DESCRIPTION
### What does this PR do?

Add a "/" to the image URLs of Jace Blob component to make it usable in engines.
Component's tests were not affected.

Related to: #[dra-3336](https://linear.app/upfluence/issue/DRA-3336/publishr-admin-web-new-campaign-creation-style-selection-modal)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
