### PR TITLE
AddressForm - Use model getter for safe access to computed property

### DIFF
--- a/addon/components/utils/address-form.ts
+++ b/addon/components/utils/address-form.ts
@@ -152,8 +152,8 @@ export default class extends Component<UtilsAddressFormArgs> {
       this.fillInAddress(place);
     });
     input.addEventListener('focusout', (event) => {
-      if ((<HTMLInputElement>event.target).value !== this.args.address[`${this.addressKey}1`]) {
-        (<HTMLInputElement>event.target).value = this.args.address[`${this.addressKey}1`] ?? '';
+      if ((<HTMLInputElement>event.target).value !== get(this.args.address, `${this.addressKey}1`)) {
+        (<HTMLInputElement>event.target).value = get(this.args.address, `${this.addressKey}1`) ?? '';
       }
     });
   }


### PR DESCRIPTION
### What does this PR do?

AddressForm - Use model getter for safe access to computed property

In the address form, when the user does not use the GOOGLE API autocompletion, it is currently impossible to add any other (non-autocomplete related) data.

The reason is that the following error from being raised when the input listener is triggered:
<img width="768" height="216" alt="Screenshot 2025-09-02 at 10 21 15" src="https://github.com/user-attachments/assets/5ba0bdf2-323e-4a23-a161-f7f0f7636b5c" />

Using the model's `get` method, we ensure we have a proper access to the attribute.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled