### PR TITLE
Add plain arg to account banner

### DIFF
--- a/addon/components/utils/account-banner.ts
+++ b/addon/components/utils/account-banner.ts
@@ -25,6 +25,7 @@ interface UtilsAccountBannerArgs {
   readonly?: boolean;
   disabled?: boolean;
   skin?: SkinType;
+  plain?: boolean;
   alert?: Alert;
 
   canSelectItem?: boolean;
@@ -52,6 +53,10 @@ export default class extends Component<UtilsAccountBannerArgs> {
     return this.args.selected ? 'account-banner--selected' : '';
   }
 
+  get plainClass(): string {
+    return this.args.plain ? 'account-banner--plain' : '';
+  }
+
   get borderColorClass(): string {
     if (this.isErrored) return 'account-banner--error';
     if (this.args.skin) return `account-banner--${this.args.skin}`;
@@ -59,7 +64,9 @@ export default class extends Component<UtilsAccountBannerArgs> {
   }
 
   get modifierClasses(): string {
-    return [this.disabledClass, this.selectedClass, this.borderColorClass].filter((mc) => !isBlank(mc)).join(' ');
+    return [this.disabledClass, this.selectedClass, this.borderColorClass, this.plainClass]
+      .filter((mc) => !isBlank(mc))
+      .join(' ');
   }
 
   get canSelectItem(): boolean {

--- a/app/styles/components/utils/account-banner.less
+++ b/app/styles/components/utils/account-banner.less
@@ -64,4 +64,16 @@
   }
 
   transition: ease-in-out 0.25s;
+
+  .upf-alert {                                                                                 
+    overflow: visible;                                                                         
+ 
+    .indicator {                                                                               
+      border-radius: var(--border-radius-md) 0 0 var(--border-radius-md);
+    }
+
+    .main-container {
+      border-radius: 0 var(--border-radius-md) var(--border-radius-md) 0;
+    }                                                                                          
+  }
 }

--- a/app/styles/components/utils/account-banner.less
+++ b/app/styles/components/utils/account-banner.less
@@ -22,6 +22,10 @@
     }
   }
 
+  &--plain {
+    .bg-color-white;
+  }
+
   &--selected {
     border-color: var(--color-primary-500);
     background-color: var(--color-primary-50);

--- a/app/styles/components/utils/account-banner.less
+++ b/app/styles/components/utils/account-banner.less
@@ -23,7 +23,7 @@
   }
 
   &--plain {
-    .bg-color-white;
+    .background-color-white;
   }
 
   &--selected {
@@ -65,15 +65,15 @@
 
   transition: ease-in-out 0.25s;
 
-  .upf-alert {                                                                                 
-    overflow: visible;                                                                         
- 
-    .indicator {                                                                               
+  .upf-alert {
+    overflow: visible;
+
+    .indicator {
       border-radius: var(--border-radius-md) 0 0 var(--border-radius-md);
     }
 
     .main-container {
       border-radius: 0 var(--border-radius-md) var(--border-radius-md) 0;
-    }                                                                                          
+    }
   }
 }

--- a/tests/integration/components/utils/account-banner-test.ts
+++ b/tests/integration/components/utils/account-banner-test.ts
@@ -130,7 +130,7 @@ module('Integration | Component | utils/account-banner', function (hooks) {
     test('it renders @subtitle', async function (assert) {
       await render(hbs`<Utils::AccountBanner @subtitle="subtitle" />`);
 
-      assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle *');
+      assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle');
     });
 
     test('it renders custom-subtitle block', async function (assert) {

--- a/tests/integration/components/utils/account-banner-test.ts
+++ b/tests/integration/components/utils/account-banner-test.ts
@@ -69,6 +69,12 @@ module('Integration | Component | utils/account-banner', function (hooks) {
       assert.dom('.account-banner').hasClass('account-banner--selected');
       assert.dom('.account-banner').hasClass('account-banner--disabled');
     });
+
+    test('@plain applies plain class', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @plain={{true}} />`);
+
+      assert.dom('.account-banner').hasClass('account-banner--plain');
+    });
   });
 
   module('icon / image', function () {
@@ -124,7 +130,7 @@ module('Integration | Component | utils/account-banner', function (hooks) {
     test('it renders @subtitle', async function (assert) {
       await render(hbs`<Utils::AccountBanner @subtitle="subtitle" />`);
 
-      assert.dom('[data-control-name="account-banner-selected-item-label"]').containsText('subtitle');
+      assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle *');
     });
 
     test('it renders custom-subtitle block', async function (assert) {


### PR DESCRIPTION
### What does this PR do?

Add plain arg to account banner to allow for a white background style
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
