### PR TITLE
Add form validation to AccountBanner for account selection

### DIFF
--- a/addon/components/utils/account-banner.hbs
+++ b/addon/components/utils/account-banner.hbs
@@ -22,70 +22,54 @@
 
       {{#if (or @subtitle (has-block "custom-subtitle"))}}
         {{#if @subtitle}}
-          <OSS::Form
-            @onSetup={{this.onFormSetup}}
-            @onSubmit={{this.noop}}
-          >
-            <:content>
-              <div class="fx-col fx-gap-px-3">
-                <div
-                  class={{concat
-                    "account-banner__selection fx-row fx-gap-px-6 fx-xalign-center "
-                    (unless this.canSelectItem " account-banner__selection--unique-account")
-                  }}
-                  role="button"
-                  data-control-name="account-banner-selection-subtitle"
-                  {{on "click" this.toggleSelectionDropdown}}
-                  {{on-click-outside this.closeSelectionDropdown}}
+          <div class="fx-col fx-gap-px-3">
+            <div
+              class={{concat
+                "account-banner__selection fx-row fx-gap-px-6 fx-xalign-center "
+                (unless this.canSelectItem " account-banner__selection--unique-account")
+              }}
+              role="button"
+              data-control-name="account-banner-selection-subtitle"
+              {{on "click" this.toggleSelectionDropdown}}
+              {{on-click-outside this.closeSelectionDropdown}}
+            >
+              {{#if @required}}
+                <span
+                  class="fx-row font-color-gray-500 text-ellipsis font-size-sm"
+                  data-control-name="account-banner-selected-item-label"
+                  {{required-input}}
                 >
-                  {{#if @selectedAccount}}
-                    <span
-                      class="font-color-gray-500 text-ellipsis font-size-sm"
-                      data-control-name="account-banner-selected-item-label"
-                    >
-                      {{@subtitle}}
-                    </span>
-                  {{else}}
-                    <span
-                      class="font-color-gray-500 text-ellipsis font-size-sm fx-row"
-                      data-control-name="account-banner-selected-item-label"
-                      {{required-input}}
-                      {{register-form-field
-                        form=this.formInstance.id
-                        fieldId="account.select"
-                        validator=this.validateAccountSelection
-                        validateOnBlur=false
-                      }}
-                    >
-                      {{@subtitle}}
-                    </span>
-                  {{/if}}
+                  {{@subtitle}}
+                </span>
+              {{else}}
+                <span
+                  class="font-color-gray-500 text-ellipsis font-size-sm"
+                  data-control-name="account-banner-selected-item-label"
+                >
+                  {{@subtitle}}
+                </span>
+              {{/if}}
 
-                  {{#if this.canSelectItem}}
-                    <OSS::Icon
-                      @icon={{if this.displaySelectableItems "fa-chevron-up" "fa-chevron-down"}}
-                      class="font-color-gray-500"
-                    />
-                    <div
-                      class="upf-floating-menu upf-floating-menu--{{if this.displaySelectableItems 'visible' 'hidden'}}"
-                    >
-                      {{#each @selectableItems as |item|}}
-                        {{#if (has-block "selectable-item")}}
-                          {{yield item this.closeSelectionDropdown to="selectable-item"}}
-                        {{/if}}
-                      {{/each}}
-                    </div>
-                  {{/if}}
+              {{#if this.canSelectItem}}
+                <OSS::Icon
+                  @icon={{if this.displaySelectableItems "fa-chevron-up" "fa-chevron-down"}}
+                  class="font-color-gray-500"
+                />
+                <div class="upf-floating-menu upf-floating-menu--{{if this.displaySelectableItems 'visible' 'hidden'}}">
+                  {{#each @selectableItems as |item|}}
+                    {{#if (has-block "selectable-item")}}
+                      {{yield item this.closeSelectionDropdown to="selectable-item"}}
+                    {{/if}}
+                  {{/each}}
                 </div>
-                {{#if this.isErrored}}
-                  <span class="font-color-error-500">
-                    {{get (form-field-feedback this.formInstance.id "account.select") "value"}}
-                  </span>
-                {{/if}}
-              </div>
-            </:content>
-          </OSS::Form>
-
+              {{/if}}
+            </div>
+            {{#if this.feedbackMessage}}
+              <span class={{concat "font-color-" this.feedbackMessage.type "-500"}}>
+                {{this.feedbackMessage.value}}
+              </span>
+            {{/if}}
+          </div>
         {{else if (has-block "custom-subtitle")}}
           {{yield to="custom-subtitle"}}
         {{/if}}

--- a/addon/components/utils/account-banner.hbs
+++ b/addon/components/utils/account-banner.hbs
@@ -21,44 +21,77 @@
       {{/if}}
 
       {{#if (or @subtitle (has-block "custom-subtitle"))}}
-        <div
-          class={{concat
-            "account-banner__selection fx-row fx-gap-px-6 fx-xalign-center "
-            (unless this.canSelectItem " account-banner__selection--unique-account")
-          }}
-          role="button"
-          data-control-name="account-banner-selection-subtitle"
-          {{on "click" this.toggleSelectionDropdown}}
-          {{on-click-outside this.closeSelectionDropdown}}
-        >
-          {{#if @subtitle}}
-            <span
-              class="font-color-gray-500 text-ellipsis font-size-sm"
-              data-control-name="account-banner-selected-item-label"
-            >
-              {{@subtitle}}
-            </span>
-          {{else if (has-block "custom-subtitle")}}
-            {{yield to="custom-subtitle"}}
-          {{/if}}
+        {{#if @subtitle}}
+          <OSS::Form
+            @onSetup={{this.onFormSetup}}
+            @onSubmit={{this.noop}}
+            data-control-name="find-creators-select-all-form"
+          >
+            <:content>
+              <div class="fx-col fx-gap-px-6">
+                <div
+                  class={{concat
+                    "account-banner__selection fx-row fx-gap-px-6 fx-xalign-center "
+                    (unless this.canSelectItem " account-banner__selection--unique-account")
+                  }}
+                  role="button"
+                  data-control-name="account-banner-selection-subtitle"
+                  {{on "click" this.toggleSelectionDropdown}}
+                  {{on-click-outside this.closeSelectionDropdown}}
+                >
+                  {{#if @selectedAccount}}
+                    <span
+                      class="font-color-gray-500 text-ellipsis font-size-sm"
+                      data-control-name="account-banner-selected-item-label"
+                    >
+                      {{@subtitle}}
+                    </span>
+                  {{else}}
 
-          {{#if this.canSelectItem}}
-            <OSS::Icon
-              @icon={{if this.displaySelectableItems "fa-chevron-up" "fa-chevron-down"}}
-              class="font-color-gray-500"
-            />
-            <div
-              class="upf-floating-menu upf-floating-menu--{{if this.displaySelectableItems 'visible' 'hidden'}}"
-              {{on-click-outside this.closeSelectionDropdown}}
-            >
-              {{#each @selectableItems as |item|}}
-                {{#if (has-block "selectable-item")}}
-                  {{yield item this.closeSelectionDropdown to="selectable-item"}}
+                    <span
+                      class="font-color-gray-500 text-ellipsis font-size-sm fx-row"
+                      data-control-name="account-banner-selected-item-label"
+                      {{required-input}}
+                      {{register-form-field
+                        form=this.formInstance.id
+                        fieldId="account.select"
+                        validator=this.validateAccountSelection
+                        validateOnBlur=false
+                      }}
+                    >
+                      {{@subtitle}}
+                    </span>
+                  {{/if}}
+
+                  {{#if this.canSelectItem}}
+                    <OSS::Icon
+                      @icon={{if this.displaySelectableItems "fa-chevron-up" "fa-chevron-down"}}
+                      class="font-color-gray-500"
+                    />
+                    <div
+                      class="upf-floating-menu upf-floating-menu--{{if this.displaySelectableItems 'visible' 'hidden'}}"
+                      {{on-click-outside this.closeSelectionDropdown}}
+                    >
+                      {{#each @selectableItems as |item|}}
+                        {{#if (has-block "selectable-item")}}
+                          {{yield item this.closeSelectionDropdown to="selectable-item"}}
+                        {{/if}}
+                      {{/each}}
+                    </div>
+                  {{/if}}
+                </div>
+                {{#if this.isErrored}}
+                  <span class="font-color-error-500">
+                    {{get (form-field-feedback this.formInstance.id "account.select") "value"}}
+                  </span>
                 {{/if}}
-              {{/each}}
-            </div>
-          {{/if}}
-        </div>
+              </div>
+            </:content>
+          </OSS::Form>
+
+        {{else if (has-block "custom-subtitle")}}
+          {{yield to="custom-subtitle"}}
+        {{/if}}
       {{/if}}
     </div>
 

--- a/addon/components/utils/account-banner.hbs
+++ b/addon/components/utils/account-banner.hbs
@@ -25,10 +25,9 @@
           <OSS::Form
             @onSetup={{this.onFormSetup}}
             @onSubmit={{this.noop}}
-            data-control-name="find-creators-select-all-form"
           >
             <:content>
-              <div class="fx-col fx-gap-px-6">
+              <div class="fx-col fx-gap-px-3">
                 <div
                   class={{concat
                     "account-banner__selection fx-row fx-gap-px-6 fx-xalign-center "
@@ -47,7 +46,6 @@
                       {{@subtitle}}
                     </span>
                   {{else}}
-
                     <span
                       class="font-color-gray-500 text-ellipsis font-size-sm fx-row"
                       data-control-name="account-banner-selected-item-label"
@@ -70,7 +68,6 @@
                     />
                     <div
                       class="upf-floating-menu upf-floating-menu--{{if this.displaySelectableItems 'visible' 'hidden'}}"
-                      {{on-click-outside this.closeSelectionDropdown}}
                     >
                       {{#each @selectableItems as |item|}}
                         {{#if (has-block "selectable-item")}}

--- a/addon/components/utils/account-banner.ts
+++ b/addon/components/utils/account-banner.ts
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { IntlService } from 'ember-intl';
 
-import { Feedback, FormInstance } from '@upfluence/oss-components/services/form-manager';
+import FormManager, { Feedback, FormInstance } from '@upfluence/oss-components/services/form-manager';
 
 type SkinType = 'success' | 'error' | 'warning';
 
@@ -38,8 +38,9 @@ interface UtilsAccountBannerArgs {
 
 export default class extends Component<UtilsAccountBannerArgs> {
   @service declare intl: IntlService;
+  @service declare formManager: FormManager;
 
-  declare formInstance: FormInstance;
+  @tracked declare formInstance: FormInstance;
 
   @tracked displaySelectableItems: boolean = false;
   @tracked isErrored: boolean = false;
@@ -53,7 +54,8 @@ export default class extends Component<UtilsAccountBannerArgs> {
   }
 
   get borderColorClass(): string {
-    if (this.args.skin || this.isErrored) return `account-banner--${this.args.skin}`;
+    if (this.isErrored && this.formInstance?.getErrors()?.['account.select']) return 'account-banner--error';
+    if (this.args.skin) return `account-banner--${this.args.skin}`;
     return '';
   }
 

--- a/addon/components/utils/account-banner.ts
+++ b/addon/components/utils/account-banner.ts
@@ -43,7 +43,10 @@ export default class extends Component<UtilsAccountBannerArgs> {
   @tracked declare formInstance: FormInstance;
 
   @tracked displaySelectableItems: boolean = false;
-  @tracked isErrored: boolean = false;
+
+  get isErrored(): boolean {
+    return !this.args.selectedAccount;
+  }
 
   get disabledClass(): string {
     return this.args.disabled ? 'account-banner--disabled' : '';
@@ -91,14 +94,11 @@ export default class extends Component<UtilsAccountBannerArgs> {
   @action
   validateAccountSelection(): Feedback | undefined {
     if (!this.args.selectedAccount) {
-      this.isErrored = true;
       return {
         kind: 'blank',
         message: { type: 'error', value: this.intl.t('oss-components.forms.errors.required') }
       };
     }
-
-    this.isErrored = false;
     return undefined;
   }
 }

--- a/addon/components/utils/account-banner.ts
+++ b/addon/components/utils/account-banner.ts
@@ -2,6 +2,10 @@ import { action } from '@ember/object';
 import { isBlank } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { IntlService } from 'ember-intl';
+
+import { Feedback, FormInstance } from '@upfluence/oss-components/services/form-manager';
 
 type SkinType = 'success' | 'error' | 'warning';
 
@@ -27,10 +31,18 @@ interface UtilsAccountBannerArgs {
 
   canSelectItem?: boolean;
   selectableItems?: any[];
+  selectedAccount?: any;
+
+  onFormSetup?(form: FormInstance): void;
 }
 
 export default class extends Component<UtilsAccountBannerArgs> {
+  @service declare intl: IntlService;
+
+  declare formInstance: FormInstance;
+
   @tracked displaySelectableItems: boolean = false;
+  @tracked isErrored: boolean = false;
 
   get disabledClass(): string {
     return this.args.disabled ? 'account-banner--disabled' : '';
@@ -41,7 +53,7 @@ export default class extends Component<UtilsAccountBannerArgs> {
   }
 
   get borderColorClass(): string {
-    if (this.args.skin) return `account-banner--${this.args.skin}`;
+    if (this.args.skin || this.isErrored) return `account-banner--${this.args.skin}`;
     return '';
   }
 
@@ -51,6 +63,14 @@ export default class extends Component<UtilsAccountBannerArgs> {
 
   get canSelectItem(): boolean {
     return ((this.args.selectableItems || []).length > 1 && this.args.canSelectItem) ?? false;
+  }
+
+  noop(): void {}
+
+  @action
+  onFormSetup(form: FormInstance): void {
+    this.formInstance = form;
+    this.args.onFormSetup?.(form);
   }
 
   @action
@@ -64,5 +84,19 @@ export default class extends Component<UtilsAccountBannerArgs> {
   @action
   closeSelectionDropdown(): void {
     this.displaySelectableItems = false;
+  }
+
+  @action
+  validateAccountSelection(): Feedback | undefined {
+    if (!this.args.selectedAccount) {
+      this.isErrored = true;
+      return {
+        kind: 'blank',
+        message: { type: 'error', value: this.intl.t('oss-components.forms.errors.required') }
+      };
+    }
+
+    this.isErrored = false;
+    return undefined;
   }
 }

--- a/addon/components/utils/account-banner.ts
+++ b/addon/components/utils/account-banner.ts
@@ -2,10 +2,8 @@ import { action } from '@ember/object';
 import { isBlank } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
-import { IntlService } from 'ember-intl';
 
-import FormManager, { Feedback, FormInstance } from '@upfluence/oss-components/services/form-manager';
+import { type FeedbackMessage } from '@upfluence/oss-components/components/o-s-s/input-container';
 
 type SkinType = 'success' | 'error' | 'warning';
 
@@ -31,21 +29,19 @@ interface UtilsAccountBannerArgs {
 
   canSelectItem?: boolean;
   selectableItems?: any[];
-  selectedAccount?: any;
-
-  onFormSetup?(form: FormInstance): void;
+  feedbackMessage?: FeedbackMessage;
+  required?: boolean;
 }
 
 export default class extends Component<UtilsAccountBannerArgs> {
-  @service declare intl: IntlService;
-  @service declare formManager: FormManager;
-
-  @tracked declare formInstance: FormInstance;
-
   @tracked displaySelectableItems: boolean = false;
 
+  get feedbackMessage(): FeedbackMessage | undefined {
+    return this.args.feedbackMessage;
+  }
+
   get isErrored(): boolean {
-    return !this.args.selectedAccount;
+    return this.feedbackMessage?.type === 'error';
   }
 
   get disabledClass(): string {
@@ -57,7 +53,7 @@ export default class extends Component<UtilsAccountBannerArgs> {
   }
 
   get borderColorClass(): string {
-    if (this.isErrored && this.formInstance?.getErrors()?.['account.select']) return 'account-banner--error';
+    if (this.isErrored) return 'account-banner--error';
     if (this.args.skin) return `account-banner--${this.args.skin}`;
     return '';
   }
@@ -68,14 +64,6 @@ export default class extends Component<UtilsAccountBannerArgs> {
 
   get canSelectItem(): boolean {
     return ((this.args.selectableItems || []).length > 1 && this.args.canSelectItem) ?? false;
-  }
-
-  noop(): void {}
-
-  @action
-  onFormSetup(form: FormInstance): void {
-    this.formInstance = form;
-    this.args.onFormSetup?.(form);
   }
 
   @action
@@ -89,16 +77,5 @@ export default class extends Component<UtilsAccountBannerArgs> {
   @action
   closeSelectionDropdown(): void {
     this.displaySelectableItems = false;
-  }
-
-  @action
-  validateAccountSelection(): Feedback | undefined {
-    if (!this.args.selectedAccount) {
-      return {
-        kind: 'blank',
-        message: { type: 'error', value: this.intl.t('oss-components.forms.errors.required') }
-      };
-    }
-    return undefined;
   }
 }

--- a/tests/integration/components/utils/account-banner-test.ts
+++ b/tests/integration/components/utils/account-banner-test.ts
@@ -3,7 +3,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { click, render, findAll } from '@ember/test-helpers';
-import sinon from 'sinon';
 
 const SELECTABLE_ITEMS = [{ label: 'Account A' }, { label: 'Account B' }, { label: 'Account C' }];
 
@@ -149,14 +148,14 @@ module('Integration | Component | utils/account-banner', function (hooks) {
       assert.dom('.custom-sub').doesNotExist();
     });
 
-    test('it marks subtitle as required when no @selectedAccount', async function (assert) {
-      await render(hbs`<Utils::AccountBanner @subtitle="subtitle" />`);
+    test('it marks subtitle as required when @required is true', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @subtitle="subtitle" @required={{true}} />`);
 
       assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle *');
     });
 
-    test('it does not mark subtitle as required when @selectedAccount is provided', async function (assert) {
-      await render(hbs`<Utils::AccountBanner @subtitle="subtitle" @selectedAccount={{true}} />`);
+    test('it does not mark subtitle as required when @required is not set', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @subtitle="subtitle" />`);
 
       assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle');
     });
@@ -331,13 +330,43 @@ module('Integration | Component | utils/account-banner', function (hooks) {
     });
   });
 
-  module('form setup', function () {
-    test('@onFormSetup is called when @subtitle is provided', async function (assert) {
-      this.set('onFormSetup', sinon.stub());
+  module('feedback message', function () {
+    test('it does not render any feedback message by default', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @subtitle="label" />`);
 
-      await render(hbs`<Utils::AccountBanner @subtitle="label" @onFormSetup={{this.onFormSetup}} />`);
+      assert.dom('.account-banner__selection + span').doesNotExist();
+    });
 
-      assert.true(this.onFormSetup.calledOnce);
+    test('it renders an error feedback message', async function (assert) {
+      this.set('feedback', { type: 'error', value: 'Required field' });
+      await render(hbs`<Utils::AccountBanner @subtitle="label" @feedbackMessage={{this.feedback}} />`);
+
+      assert.dom('.account-banner__selection + span').exists();
+      assert.dom('.account-banner__selection + span').hasClass('font-color-error-500');
+      assert.dom('.account-banner__selection + span').hasText('Required field');
+    });
+
+    test('it renders a warning feedback message', async function (assert) {
+      this.set('feedback', { type: 'warning', value: 'Be careful' });
+      await render(hbs`<Utils::AccountBanner @subtitle="label" @feedbackMessage={{this.feedback}} />`);
+
+      assert.dom('.account-banner__selection + span').exists();
+      assert.dom('.account-banner__selection + span').hasClass('font-color-warning-500');
+      assert.dom('.account-banner__selection + span').hasText('Be careful');
+    });
+
+    test('it applies error border class when feedbackMessage type is error', async function (assert) {
+      this.set('feedback', { type: 'error', value: 'Required field' });
+      await render(hbs`<Utils::AccountBanner @subtitle="label" @feedbackMessage={{this.feedback}} />`);
+
+      assert.dom('.account-banner').hasClass('account-banner--error');
+    });
+
+    test('it does not apply error border class when feedbackMessage type is warning', async function (assert) {
+      this.set('feedback', { type: 'warning', value: 'Be careful' });
+      await render(hbs`<Utils::AccountBanner @subtitle="label" @feedbackMessage={{this.feedback}} />`);
+
+      assert.dom('.account-banner').hasNoClass('account-banner--error');
     });
   });
 

--- a/tests/integration/components/utils/account-banner-test.ts
+++ b/tests/integration/components/utils/account-banner-test.ts
@@ -3,12 +3,27 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { click, render, findAll } from '@ember/test-helpers';
+import sinon from 'sinon';
 
 const SELECTABLE_ITEMS = [{ label: 'Account A' }, { label: 'Account B' }, { label: 'Account C' }];
 
 module('Integration | Component | utils/account-banner', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
+
+  module('rendering', function () {
+    test('it renders', async function (assert) {
+      await render(hbs`<Utils::AccountBanner />`);
+
+      assert.dom('.account-banner').exists();
+    });
+
+    test('it forwards HTML attributes', async function (assert) {
+      await render(hbs`<Utils::AccountBanner data-test="banner" />`);
+
+      assert.dom('.account-banner[data-test="banner"]').exists();
+    });
+  });
 
   module('modifier classes', function () {
     test('it renders with no modifier classes by default', async function (assert) {
@@ -57,6 +72,27 @@ module('Integration | Component | utils/account-banner', function (hooks) {
     });
   });
 
+  module('icon / image', function () {
+    test('it renders @icon', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @icon="fa-circle" />`);
+
+      assert.dom('.upf-badge').exists();
+    });
+
+    test('it renders @image as a badge', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @image="/some/image.svg" />`);
+
+      assert.dom('.icon-in-badge').exists();
+    });
+
+    test('@icon takes precedence over @image', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @icon="fa-circle" @image="/some/image.svg" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.icon-in-badge').doesNotExist();
+    });
+  });
+
   module('title', function () {
     test('it renders @title', async function (assert) {
       await render(hbs`<Utils::AccountBanner @title="title" />`);
@@ -89,7 +125,7 @@ module('Integration | Component | utils/account-banner', function (hooks) {
     test('it renders @subtitle', async function (assert) {
       await render(hbs`<Utils::AccountBanner @subtitle="subtitle" />`);
 
-      assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle');
+      assert.dom('[data-control-name="account-banner-selected-item-label"]').containsText('subtitle');
     });
 
     test('it renders custom-subtitle block', async function (assert) {
@@ -113,30 +149,36 @@ module('Integration | Component | utils/account-banner', function (hooks) {
       assert.dom('.custom-sub').doesNotExist();
     });
 
+    test('it marks subtitle as required when no @selectedAccount', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @subtitle="subtitle" />`);
+
+      assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle *');
+    });
+
+    test('it does not mark subtitle as required when @selectedAccount is provided', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @subtitle="subtitle" @selectedAccount={{true}} />`);
+
+      assert.dom('[data-control-name="account-banner-selected-item-label"]').hasText('subtitle');
+    });
+
     test('account-banner__selection is not rendered without subtitle or custom-subtitle', async function (assert) {
       await render(hbs`<Utils::AccountBanner />`);
 
       assert.dom('.account-banner__selection').doesNotExist();
     });
-  });
 
-  module('actions block', function () {
-    test('it renders the actions block', async function (assert) {
-      await render(hbs`
-        <Utils::AccountBanner>
-          <:actions><span class="action">action</span></:actions>
-        </Utils::AccountBanner>
-      `);
+    test('unique-account class is applied when canSelectItem is false', async function (assert) {
+      await render(hbs`<Utils::AccountBanner @subtitle="label" />`);
 
-      assert.dom('.action').exists();
+      assert.dom('.account-banner__selection--unique-account').exists();
     });
   });
 
-  module('dropdown', function () {
+  module('selection dropdown', function () {
     test('chevron is not rendered without canSelectItem', async function (assert) {
       await render(hbs`<Utils::AccountBanner @subtitle="label" @selected={{true}} />`);
 
-      assert.dom('.fa-chevron-down').doesNotExist();
+      assert.dom('.fa-chevron-down, [data-icon="chevron-down"]').doesNotExist();
     });
 
     test('chevron is not rendered with only 1 item', async function (assert) {
@@ -149,10 +191,12 @@ module('Integration | Component | utils/account-banner', function (hooks) {
         />
       `);
 
-      assert.dom('[data-icon="chevron-down"]').doesNotExist();
+      assert.dom('.fa-chevron-down, [data-icon="chevron-down"]').doesNotExist();
     });
 
     test('chevron is rendered with canSelectItem and multiple items', async function (assert) {
+      this.set('items', SELECTABLE_ITEMS);
+
       await render(hbs`
         <Utils::AccountBanner
           @subtitle="label"
@@ -162,7 +206,6 @@ module('Integration | Component | utils/account-banner', function (hooks) {
         />
       `);
 
-      this.set('items', SELECTABLE_ITEMS);
       assert.dom('.fa-chevron-down, [data-icon="chevron-down"]').exists();
     });
 
@@ -286,11 +329,15 @@ module('Integration | Component | utils/account-banner', function (hooks) {
 
       assert.strictEqual(findAll('.item').length, SELECTABLE_ITEMS.length);
     });
+  });
 
-    test('unique-account class applied when canSelectItem is false', async function (assert) {
-      await render(hbs`<Utils::AccountBanner @subtitle="label" />`);
+  module('form setup', function () {
+    test('@onFormSetup is called when @subtitle is provided', async function (assert) {
+      this.set('onFormSetup', sinon.stub());
 
-      assert.dom('.account-banner__selection--unique-account').exists();
+      await render(hbs`<Utils::AccountBanner @subtitle="label" @onFormSetup={{this.onFormSetup}} />`);
+
+      assert.true(this.onFormSetup.calledOnce);
     });
   });
 
@@ -328,17 +375,15 @@ module('Integration | Component | utils/account-banner', function (hooks) {
     });
   });
 
-  module('image / icon', function () {
-    test('it renders @image as a badge', async function (assert) {
-      await render(hbs`<Utils::AccountBanner @image="/some/image.svg" />`);
+  module('actions block', function () {
+    test('it renders the actions block', async function (assert) {
+      await render(hbs`
+        <Utils::AccountBanner>
+          <:actions><span class="action">action</span></:actions>
+        </Utils::AccountBanner>
+      `);
 
-      assert.dom('.icon-in-badge').exists();
-    });
-
-    test('it renders @icon', async function (assert) {
-      await render(hbs`<Utils::AccountBanner @icon="fa-circle" />`);
-
-      assert.dom('.upf-badge').exists();
+      assert.dom('.action').exists();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

  Add form validation logic to the `Utils::AccountBanner` component to handle account selection from the side panel.           
   
  - Integrate `OSS::Form` in the subtitle area to register a required form field (`account.select`)                            
  - Conditionally display the required marker (`*`) and validation modifiers based on `@selectedAccount` presence
  - Expose an `@onFormSetup` callback so consumers can access the form instance                                                
  - Handle error state (red border + message) via a getter derived from `@selectedAccount` and form errors

### What are the observable changes?

[Screencast from 2026-04-02 17-31-05.webm](https://github.com/user-attachments/assets/274e1ddf-a981-4dd5-b6d7-3c0422895b3c)


### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
