### PR TITLE
Add 'sm' to SmartBlob's size options

### DIFF
--- a/addon/components/utils/smart-blob.ts
+++ b/addon/components/utils/smart-blob.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 
-type Size = 'md' | 'xl';
+type Size = 'sm' | 'md' | 'xl';
 interface SmartBlobArgs {
   loading: boolean;
   size: Size;

--- a/app/styles/components/smart-blob.less
+++ b/app/styles/components/smart-blob.less
@@ -5,6 +5,16 @@
   border-radius: 100%;
   transition: all 1s ease-in-out;
 
+  &--sm {
+    height: 22px;
+    width: 22px;
+
+    .smart-blob {
+      width: 22px;
+      height: 22px;
+    }
+  }
+
   &--xl {
     height: 64px;
     width: 64px;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,6 +22,7 @@
   />
   <div class="fx-row fx-gap-px-12 fx-xalign-center">
     <OSS::ToggleSwitch @value={{this.blobLoading}} @onChange={{this.onBlobSwitch}} />
+    <Utils::SmartBlob @loading={{this.blobLoading}} @size="sm" />
     <Utils::SmartBlob @loading={{this.blobLoading}} />
     <Utils::SmartBlob @loading={{this.blobLoading}} @size="xl" />
   </div>

--- a/tests/integration/components/utils/smart-blob-test.ts
+++ b/tests/integration/components/utils/smart-blob-test.ts
@@ -39,11 +39,13 @@ module('Integration | Component | utils/smart-blob', function (hooks) {
   });
 
   module('@size', function () {
-    test('it applies the correct size class', async function (assert) {
-      this.set('size', 'xl');
-      await render(hbs`<Utils::SmartBlob @size={{this.size}} />`);
+    ['sm', 'xl', 'md'].forEach((size) => {
+      test(`it applies the correct size class for @size='${size}'`, async function (assert) {
+        this.set('size', size);
+        await render(hbs`<Utils::SmartBlob @size={{this.size}} />`);
 
-      assert.dom('.smart-blob-container').hasClass('smart-blob-container--xl');
+        assert.dom('.smart-blob-container').hasClass(`smart-blob-container--${size}`);
+      });
     });
 
     test('it defaults to md size', async function (assert) {


### PR DESCRIPTION
### What does this PR do?

SmartBlob now handles `'sm'` size in addition to default `'md'` and `'xl'`
<img width="158" height="85" alt="Capture d’écran 2026-04-22 à 17 10 46" src="https://github.com/user-attachments/assets/cdca1f84-7df1-4c4c-a5f2-a93518b745b4" />

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
