### PR TITLE
Add support for SmartConversation::Message component

### DIFF
--- a/addon/components/utils/smart-conversation/message.hbs
+++ b/addon/components/utils/smart-conversation/message.hbs
@@ -1,0 +1,22 @@
+<div
+  class={{this.computedClasses}}
+  role="button"
+  data-control-name="smart-conversation-message"
+  {{on "click" this.toggleCollapsed}}
+>
+  <div class="content">
+    {{#if (eq @type "smart_reply")}}
+      <Utils::SmartBlob @size="md" />
+    {{/if}}
+
+    <div class="fx-col fx-gap-px-18">
+      <span>{{@value}}</span>
+
+      {{#if (has-block "extra-content")}}
+        {{yield to="extra-content"}}
+      {{/if}}
+    </div>
+  </div>
+
+  <span class="font-color-gray-400 font-size-xs">{{this.formattedTimestamp}}</span>
+</div>

--- a/addon/components/utils/smart-conversation/message.hbs
+++ b/addon/components/utils/smart-conversation/message.hbs
@@ -3,6 +3,7 @@
   role="button"
   data-control-name="smart-conversation-message"
   {{on "click" this.toggleCollapsed}}
+  ...attributes
 >
   <div class="content" {{did-insert this.measureOverflow}}>
     {{#if (eq @type "smart_reply")}}

--- a/addon/components/utils/smart-conversation/message.hbs
+++ b/addon/components/utils/smart-conversation/message.hbs
@@ -4,7 +4,7 @@
   data-control-name="smart-conversation-message"
   {{on "click" this.toggleCollapsed}}
 >
-  <div class="content">
+  <div class="content" {{did-insert this.measureOverflow}}>
     {{#if (eq @type "smart_reply")}}
       <Utils::SmartBlob @size="md" />
     {{/if}}

--- a/addon/components/utils/smart-conversation/message.ts
+++ b/addon/components/utils/smart-conversation/message.ts
@@ -1,0 +1,40 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import moment from 'moment';
+
+interface UtilsSmartConversationMessageComponentSignature {
+  type: 'smart_reply' | 'user_prompt';
+  value: string;
+  timestamp: number;
+}
+
+export default class UtilsSmartConversationMessageComponent extends Component<UtilsSmartConversationMessageComponentSignature> {
+  @tracked collapsed: boolean = true;
+
+  get collapsible(): boolean {
+    return this.args.type === 'smart_reply';
+  }
+
+  get computedClasses(): string {
+    const classes = ['smart-conversation-message', `smart-conversation-message--${this.args.type}`];
+
+    if (this.collapsible && this.collapsed) {
+      classes.push('smart-conversation-message--collapsed');
+    }
+
+    return classes.join(' ');
+  }
+
+  get formattedTimestamp(): string {
+    return moment(this.args.timestamp).format('DD/MM/YYYY, HH:mm');
+  }
+
+  toggleCollapsed = (event: MouseEvent) => {
+    event.stopPropagation();
+
+    if (!this.collapsible) return;
+
+    this.collapsed = !this.collapsed;
+  };
+}

--- a/addon/components/utils/smart-conversation/message.ts
+++ b/addon/components/utils/smart-conversation/message.ts
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -30,11 +31,12 @@ export default class UtilsSmartConversationMessageComponent extends Component<Ut
     return moment(this.args.timestamp).format('DD/MM/YYYY, HH:mm');
   }
 
-  toggleCollapsed = (event: MouseEvent) => {
+  @action
+  toggleCollapsed(event: MouseEvent): void {
     event.stopPropagation();
 
     if (!this.collapsible) return;
 
     this.collapsed = !this.collapsed;
-  };
+  }
 }

--- a/addon/components/utils/smart-conversation/message.ts
+++ b/addon/components/utils/smart-conversation/message.ts
@@ -6,6 +6,7 @@ import moment from 'moment';
 
 interface UtilsSmartConversationMessageComponentSignature {
   type: 'smart_reply' | 'user_prompt';
+  collapsible?: boolean;
   value: string;
   timestamp: number;
 }
@@ -14,7 +15,7 @@ export default class UtilsSmartConversationMessageComponent extends Component<Ut
   @tracked collapsed: boolean = true;
 
   get collapsible(): boolean {
-    return this.args.type === 'smart_reply';
+    return this.args.collapsible ?? true;
   }
 
   get computedClasses(): string {

--- a/addon/components/utils/smart-conversation/message.ts
+++ b/addon/components/utils/smart-conversation/message.ts
@@ -11,8 +11,6 @@ interface UtilsSmartConversationMessageComponentSignature {
   timestamp: number;
 }
 
-const COLLAPSED_MAX_HEIGHT = 130;
-
 export default class UtilsSmartConversationMessageComponent extends Component<UtilsSmartConversationMessageComponentSignature> {
   @tracked collapsed: boolean = true;
   @tracked overflows: boolean = false;
@@ -33,7 +31,9 @@ export default class UtilsSmartConversationMessageComponent extends Component<Ut
 
   @action
   measureOverflow(element: HTMLElement): void {
-    this.overflows = element.scrollHeight > COLLAPSED_MAX_HEIGHT;
+    const maxHeight = parseFloat(getComputedStyle(element).getPropertyValue('--collapsed-max-height'));
+
+    this.overflows = element.scrollHeight > maxHeight;
   }
 
   @action

--- a/addon/components/utils/smart-conversation/message.ts
+++ b/addon/components/utils/smart-conversation/message.ts
@@ -14,10 +14,6 @@ interface UtilsSmartConversationMessageComponentSignature {
 export default class UtilsSmartConversationMessageComponent extends Component<UtilsSmartConversationMessageComponentSignature> {
   @tracked collapsed: boolean = true;
 
-  get collapsible(): boolean {
-    return this.args.collapsible ?? true;
-  }
-
   get computedClasses(): string {
     const classes = ['smart-conversation-message', `smart-conversation-message--${this.args.type}`];
 
@@ -39,5 +35,9 @@ export default class UtilsSmartConversationMessageComponent extends Component<Ut
     if (!this.collapsible) return;
 
     this.collapsed = !this.collapsed;
+  }
+
+  private get collapsible(): boolean {
+    return this.args.collapsible ?? true;
   }
 }

--- a/addon/components/utils/smart-conversation/message.ts
+++ b/addon/components/utils/smart-conversation/message.ts
@@ -11,13 +11,16 @@ interface UtilsSmartConversationMessageComponentSignature {
   timestamp: number;
 }
 
+const COLLAPSED_MAX_HEIGHT = 130;
+
 export default class UtilsSmartConversationMessageComponent extends Component<UtilsSmartConversationMessageComponentSignature> {
   @tracked collapsed: boolean = true;
+  @tracked overflows: boolean = false;
 
   get computedClasses(): string {
     const classes = ['smart-conversation-message', `smart-conversation-message--${this.args.type}`];
 
-    if (this.collapsible && this.collapsed) {
+    if (this.collapsible && this.collapsed && this.overflows) {
       classes.push('smart-conversation-message--collapsed');
     }
 
@@ -29,10 +32,15 @@ export default class UtilsSmartConversationMessageComponent extends Component<Ut
   }
 
   @action
+  measureOverflow(element: HTMLElement): void {
+    this.overflows = element.scrollHeight > COLLAPSED_MAX_HEIGHT;
+  }
+
+  @action
   toggleCollapsed(event: MouseEvent): void {
     event.stopPropagation();
 
-    if (!this.collapsible) return;
+    if (!this.collapsible || !this.overflows) return;
 
     this.collapsed = !this.collapsed;
   }

--- a/app/components/utils/smart-conversation/message.js
+++ b/app/components/utils/smart-conversation/message.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/ember-upf-utils/components/utils/smart-conversation/message';

--- a/app/styles/components/smart-conversation.less
+++ b/app/styles/components/smart-conversation.less
@@ -5,6 +5,7 @@
   flex-direction: column;
   gap: var(--spacing-px-3);
   align-items: flex-end;
+  max-width: 70%;
 
   .content {
     border-radius: var(--border-radius-lg);

--- a/app/styles/components/smart-conversation.less
+++ b/app/styles/components/smart-conversation.less
@@ -1,0 +1,47 @@
+@import url('https://fonts.googleapis.com/css?family=Reddit+Sans:wght@400,600&family=Open+Sans:400,400i,600,600i,700,700i&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese');
+
+.smart-conversation-message {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-px-3);
+  align-items: flex-end;
+
+  .content {
+    border-radius: var(--border-radius-lg);
+    display: flex;
+    gap: var(--spacing-px-18);
+    padding: var(--spacing-px-12) var(--spacing-px-18);
+    font-size: var(--font-size-md);
+    font-family: 'Reddit Sans', sans-serif;
+    position: relative;
+  }
+
+  &--smart_reply .content {
+    border: 1px solid transparent;
+    background: linear-gradient(45deg, var(--color-white) 0%, var(--color-primary-50) 100%) padding-box,
+      linear-gradient(90deg, var(--color-primary-100) 0%, var(--color-white) 72.5%) border-box;
+
+    color: var(--color-primary-400);
+  }
+
+  &--user_prompt .content {
+    background-color: var(--color-gray-100);
+    color: var(--color-gray-900);
+    padding: var(--spacing-px-12);
+  }
+
+  &--collapsed .content {
+    max-height: 130px;
+    overflow-y: hidden;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 40px;
+      background: linear-gradient(to top, var(--color-gray-50), transparent 40px);
+    }
+  }
+}

--- a/app/styles/components/smart-conversation.less
+++ b/app/styles/components/smart-conversation.less
@@ -21,7 +21,8 @@
 
   &--smart_reply .content {
     border: 1px solid transparent;
-    background: linear-gradient(45deg, var(--color-white) 0%, var(--color-primary-50) 100%) padding-box,
+    background:
+      linear-gradient(45deg, var(--color-white) 0%, var(--color-primary-50) 100%) padding-box,
       linear-gradient(90deg, var(--color-primary-100) 0%, var(--color-white) 72.5%) border-box;
 
     color: var(--color-primary-400);

--- a/app/styles/components/smart-conversation.less
+++ b/app/styles/components/smart-conversation.less
@@ -8,6 +8,8 @@
   max-width: 70%;
 
   .content {
+    --collapsed-max-height: 130px;
+
     border-radius: var(--border-radius-lg);
     display: flex;
     gap: var(--spacing-px-18);
@@ -32,7 +34,7 @@
   }
 
   &--collapsed .content {
-    max-height: 130px;
+    max-height: var(--collapsed-max-height);
     overflow-y: hidden;
 
     &::after {

--- a/app/styles/upf-utils.less
+++ b/app/styles/upf-utils.less
@@ -8,6 +8,7 @@
 @import 'components/http-errors-code';
 @import 'components/logo-maker';
 @import 'components/smart-blob';
+@import 'components/smart-conversation';
 @import 'components/uedit-file-uploader';
 @import 'components/utm-link-builder';
 @import 'components/utils/social-media-handler';

--- a/tests/integration/components/utils/smart-conversation/message-test.ts
+++ b/tests/integration/components/utils/smart-conversation/message-test.ts
@@ -7,14 +7,11 @@ import moment from 'moment';
 module('Integration | Component | utils/smart-conversation/message', function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    this.timestamp = moment('2026-05-05').valueOf();
-  });
-
   module('User prompt', function (hooks) {
     hooks.beforeEach(function () {
       this.type = 'user_prompt';
-      this.value = 'This is a smart reply';
+      this.value = 'Gimme, gimme, gimme a creator after midnight';
+      this.timestamp = moment('2026-05-05').valueOf();
     });
 
     test('it renders properly', async function (assert) {
@@ -25,7 +22,7 @@ module('Integration | Component | utils/smart-conversation/message', function (h
       assert.dom('.smart-conversation-message').exists();
       assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--user_prompt');
       assert.dom('.smart-conversation-message--collapsed').doesNotExist();
-      assert.dom('.smart-conversation-message .content').hasText(this.value);
+      assert.dom('.smart-conversation-message .content').hasText('Gimme, gimme, gimme a creator after midnight');
       assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('05/05/2026, 00:00');
     });
 
@@ -60,6 +57,7 @@ module('Integration | Component | utils/smart-conversation/message', function (h
     hooks.beforeEach(function () {
       this.type = 'smart_reply';
       this.value = 'This is a smart reply';
+      this.timestamp = moment('2026-04-22').valueOf();
     });
 
     test('it renders properly', async function (assert) {
@@ -71,7 +69,7 @@ module('Integration | Component | utils/smart-conversation/message', function (h
       assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--smart_reply');
       assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--collapsed');
       assert.dom('.smart-conversation-message .content').hasText(this.value);
-      assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('05/05/2026, 00:00');
+      assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('22/04/2026, 00:00');
     });
 
     test('it toggles collapsed state on click', async function (assert) {

--- a/tests/integration/components/utils/smart-conversation/message-test.ts
+++ b/tests/integration/components/utils/smart-conversation/message-test.ts
@@ -1,26 +1,106 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import moment from 'moment';
 
 module('Integration | Component | utils/smart-conversation/message', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function (val) { ... });
+  hooks.beforeEach(function () {
+    this.timestamp = moment('2026-05-05').valueOf();
+  });
 
-    await render(hbs`<Utils::SmartConversation::Message />`);
+  module('User prompt', function (hooks) {
+    hooks.beforeEach(function () {
+      this.type = 'user_prompt';
+      this.value = 'This is a smart reply';
+    });
 
-    assert.dom().hasText('');
+    test('it renders properly', async function (assert) {
+      await render(
+        hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+      );
 
-    // Template block usage:
-    await render(hbs`
-      <Utils::SmartConversation::Message>
-        template block text
-      </Utils::SmartConversation::Message>
-    `);
+      assert.dom('.smart-conversation-message').exists();
+      assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--user_prompt');
+      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+      assert.dom('.smart-conversation-message .content').hasText(this.value);
+      assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('05/05/2026, 00:00');
+    });
 
-    assert.dom().hasText('template block text');
+    test('it is not collapsible at all', async function (assert) {
+      await render(
+        hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+      );
+
+      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+
+      await click('.smart-conversation-message');
+      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+    });
+
+    test('the extra-content named block is rendered when provided', async function (assert) {
+      await render(
+        hbs`
+          <Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}>
+            <:extra-content>
+              <div class="extra-content">Extra content</div>
+            </:extra-content>
+          </Utils::SmartConversation::Message>
+        `
+      );
+
+      assert.dom('.extra-content').exists();
+      assert.dom('.extra-content').hasText('Extra content');
+    });
+  });
+
+  module('Smart reply', function (hooks) {
+    hooks.beforeEach(function () {
+      this.type = 'smart_reply';
+      this.value = 'This is a smart reply';
+    });
+
+    test('it renders properly', async function (assert) {
+      await render(
+        hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+      );
+
+      assert.dom('.smart-conversation-message').exists();
+      assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--smart_reply');
+      assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--collapsed');
+      assert.dom('.smart-conversation-message .content').hasText(this.value);
+      assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('05/05/2026, 00:00');
+    });
+
+    test('it toggles collapsed state on click', async function (assert) {
+      await render(
+        hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+      );
+
+      assert.dom('.smart-conversation-message--collapsed').exists();
+
+      await click('.smart-conversation-message');
+      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+
+      await click('.smart-conversation-message');
+      assert.dom('.smart-conversation-message--collapsed').exists();
+    });
+
+    test('the extra-content named block is rendered when provided', async function (assert) {
+      await render(
+        hbs`
+          <Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}>
+            <:extra-content>
+              <div class="extra-content">Extra content</div>
+            </:extra-content>
+          </Utils::SmartConversation::Message>
+        `
+      );
+
+      assert.dom('.extra-content').exists();
+      assert.dom('.extra-content').hasText('Extra content');
+    });
   });
 });

--- a/tests/integration/components/utils/smart-conversation/message-test.ts
+++ b/tests/integration/components/utils/smart-conversation/message-test.ts
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | utils/smart-conversation/message', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function (val) { ... });
+
+    await render(hbs`<Utils::SmartConversation::Message />`);
+
+    assert.dom().hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Utils::SmartConversation::Message>
+        template block text
+      </Utils::SmartConversation::Message>
+    `);
+
+    assert.dom().hasText('template block text');
+  });
+});

--- a/tests/integration/components/utils/smart-conversation/message-test.ts
+++ b/tests/integration/components/utils/smart-conversation/message-test.ts
@@ -4,6 +4,9 @@ import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import moment from 'moment';
 
+const LONG_VALUE = 'Lorem ipsum dolor sit amet, '.repeat(100);
+const SHORT_VALUE = 'Short message';
+
 module('Integration | Component | utils/smart-conversation/message', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -21,7 +24,6 @@ module('Integration | Component | utils/smart-conversation/message', function (h
 
       assert.dom('.smart-conversation-message').exists();
       assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--user_prompt');
-      assert.dom('.smart-conversation-message--collapsed').exists();
       assert.dom('.smart-conversation-message .content').hasText('Gimme, gimme, gimme a creator after midnight');
       assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('05/05/2026, 00:00');
     });
@@ -56,7 +58,6 @@ module('Integration | Component | utils/smart-conversation/message', function (h
 
       assert.dom('.smart-conversation-message').exists();
       assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--smart_reply');
-      assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--collapsed');
       assert.dom('.smart-conversation-message .content').hasText(this.value);
       assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('22/04/2026, 00:00');
     });
@@ -79,68 +80,95 @@ module('Integration | Component | utils/smart-conversation/message', function (h
 
   module('Collapsible message', function () {
     ['user_prompt', 'smart_reply'].forEach((type) => {
-      hooks.beforeEach(function () {
-        this.type = type;
-      });
+      module(`when type is ${type}`, function (hooks) {
+        hooks.beforeEach(function () {
+          this.type = type;
+          this.value = LONG_VALUE;
+          this.timestamp = moment('2026-05-05').valueOf();
+        });
 
-      test(`By default, message is collapsible for ${type}`, async function (assert) {
-        await render(
-          hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-        );
+        test('by default, an overflowing message is collapsible', async function (assert) {
+          await render(
+            hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
 
-        assert.dom('.smart-conversation-message--collapsed').exists();
+          assert.dom('.smart-conversation-message--collapsed').exists();
 
-        await click('.smart-conversation-message');
-        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
-      });
+          await click('.smart-conversation-message');
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+        });
 
-      test('when no @collapsible argument is provided, it defaults to true', async function (assert) {
-        await render(
-          hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-        );
+        test('when no @collapsible argument is provided, it defaults to true', async function (assert) {
+          await render(
+            hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
 
-        assert.dom('.smart-conversation-message--collapsed').exists();
-      });
+          assert.dom('.smart-conversation-message--collapsed').exists();
+        });
 
-      test('when a falsy @collapsible argument is provided, message is not collapsed', async function (assert) {
-        await render(
-          hbs`<Utils::SmartConversation::Message @collapsible={{false}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-        );
+        test('when a falsy @collapsible argument is provided, message is not collapsed', async function (assert) {
+          await render(
+            hbs`<Utils::SmartConversation::Message @collapsible={{false}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
 
-        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
-      });
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+        });
 
-      test('when a falsy @collapsible argument is provided, message is not collapsible', async function (assert) {
-        await render(
-          hbs`<Utils::SmartConversation::Message @collapsible={{false}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-        );
+        test('when a falsy @collapsible argument is provided, message is not collapsible', async function (assert) {
+          await render(
+            hbs`<Utils::SmartConversation::Message @collapsible={{false}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
 
-        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
 
-        await click('.smart-conversation-message');
-        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
-      });
+          await click('.smart-conversation-message');
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+        });
 
-      test('when a truthy @collapsible argument is provided, message is collapsed', async function (assert) {
-        await render(
-          hbs`<Utils::SmartConversation::Message @collapsible={{true}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-        );
+        test('when a truthy @collapsible argument is provided, an overflowing message is collapsed', async function (assert) {
+          await render(
+            hbs`<Utils::SmartConversation::Message @collapsible={{true}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
 
-        assert.dom('.smart-conversation-message--collapsed').exists();
-      });
+          assert.dom('.smart-conversation-message--collapsed').exists();
+        });
 
-      test('it toggles collapsed state on click', async function (assert) {
-        await render(
-          hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-        );
+        test('it toggles collapsed state on click when content overflows', async function (assert) {
+          await render(
+            hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
 
-        assert.dom('.smart-conversation-message--collapsed').exists();
+          assert.dom('.smart-conversation-message--collapsed').exists();
 
-        await click('.smart-conversation-message');
-        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+          await click('.smart-conversation-message');
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
 
-        await click('.smart-conversation-message');
-        assert.dom('.smart-conversation-message--collapsed').exists();
+          await click('.smart-conversation-message');
+          assert.dom('.smart-conversation-message--collapsed').exists();
+        });
+
+        test('when content fits within max height, message is not visually collapsed', async function (assert) {
+          this.value = SHORT_VALUE;
+
+          await render(
+            hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
+
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+        });
+
+        test('clicking a non-overflowing message does not toggle collapsed state', async function (assert) {
+          this.value = SHORT_VALUE;
+
+          await render(
+            hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+          );
+
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+
+          await click('.smart-conversation-message');
+          assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+        });
       });
     });
   });

--- a/tests/integration/components/utils/smart-conversation/message-test.ts
+++ b/tests/integration/components/utils/smart-conversation/message-test.ts
@@ -1,8 +1,9 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
+
 import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
 import moment from 'moment';
+import { module, test } from 'qunit';
 
 const LONG_VALUE = 'Lorem ipsum dolor sit amet, '.repeat(100);
 const SHORT_VALUE = 'Short message';

--- a/tests/integration/components/utils/smart-conversation/message-test.ts
+++ b/tests/integration/components/utils/smart-conversation/message-test.ts
@@ -21,20 +21,9 @@ module('Integration | Component | utils/smart-conversation/message', function (h
 
       assert.dom('.smart-conversation-message').exists();
       assert.dom('.smart-conversation-message').hasClass('smart-conversation-message--user_prompt');
-      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+      assert.dom('.smart-conversation-message--collapsed').exists();
       assert.dom('.smart-conversation-message .content').hasText('Gimme, gimme, gimme a creator after midnight');
       assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('05/05/2026, 00:00');
-    });
-
-    test('it is not collapsible at all', async function (assert) {
-      await render(
-        hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-      );
-
-      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
-
-      await click('.smart-conversation-message');
-      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
     });
 
     test('the extra-content named block is rendered when provided', async function (assert) {
@@ -72,20 +61,6 @@ module('Integration | Component | utils/smart-conversation/message', function (h
       assert.dom('.smart-conversation-message span.font-color-gray-400').hasText('22/04/2026, 00:00');
     });
 
-    test('it toggles collapsed state on click', async function (assert) {
-      await render(
-        hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
-      );
-
-      assert.dom('.smart-conversation-message--collapsed').exists();
-
-      await click('.smart-conversation-message');
-      assert.dom('.smart-conversation-message--collapsed').doesNotExist();
-
-      await click('.smart-conversation-message');
-      assert.dom('.smart-conversation-message--collapsed').exists();
-    });
-
     test('the extra-content named block is rendered when provided', async function (assert) {
       await render(
         hbs`
@@ -99,6 +74,74 @@ module('Integration | Component | utils/smart-conversation/message', function (h
 
       assert.dom('.extra-content').exists();
       assert.dom('.extra-content').hasText('Extra content');
+    });
+  });
+
+  module('Collapsible message', function () {
+    ['user_prompt', 'smart_reply'].forEach((type) => {
+      hooks.beforeEach(function () {
+        this.type = type;
+      });
+
+      test(`By default, message is collapsible for ${type}`, async function (assert) {
+        await render(
+          hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+        );
+
+        assert.dom('.smart-conversation-message--collapsed').exists();
+
+        await click('.smart-conversation-message');
+        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+      });
+
+      test('when no @collapsible argument is provided, it defaults to true', async function (assert) {
+        await render(
+          hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+        );
+
+        assert.dom('.smart-conversation-message--collapsed').exists();
+      });
+
+      test('when a falsy @collapsible argument is provided, message is not collapsed', async function (assert) {
+        await render(
+          hbs`<Utils::SmartConversation::Message @collapsible={{false}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+        );
+
+        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+      });
+
+      test('when a falsy @collapsible argument is provided, message is not collapsible', async function (assert) {
+        await render(
+          hbs`<Utils::SmartConversation::Message @collapsible={{false}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+        );
+
+        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+
+        await click('.smart-conversation-message');
+        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+      });
+
+      test('when a truthy @collapsible argument is provided, message is collapsed', async function (assert) {
+        await render(
+          hbs`<Utils::SmartConversation::Message @collapsible={{true}} @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+        );
+
+        assert.dom('.smart-conversation-message--collapsed').exists();
+      });
+
+      test('it toggles collapsed state on click', async function (assert) {
+        await render(
+          hbs`<Utils::SmartConversation::Message @type={{this.type}} @value={{this.value}} @timestamp={{this.timestamp}}/>`
+        );
+
+        assert.dom('.smart-conversation-message--collapsed').exists();
+
+        await click('.smart-conversation-message');
+        assert.dom('.smart-conversation-message--collapsed').doesNotExist();
+
+        await click('.smart-conversation-message');
+        assert.dom('.smart-conversation-message--collapsed').exists();
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Add support for SmartConversation::Message component, to be used in Chat-like UIs w/ our LLM provider backed.

The message is properly styled depending on whether it's a user prompt or a reply from the system, with replies being also collapsible (collapsed by default)

### What are the observable changes?

<img width="1900" height="398" alt="Screenshot 2026-05-05 at 13 13 37" src="https://github.com/user-attachments/assets/17872e5f-8ab7-4ad0-a5bc-473c61c1a16c" />
<img width="2732" height="490" alt="Screenshot 2026-05-05 at 13 13 32" src="https://github.com/user-attachments/assets/c87a3812-2f89-4aa5-9fc0-03c8e303fbdb" />


### 🧑‍💻 Developer Heads Up
⚡ Since we are using [Ember Octane](https://blog.emberjs.com/octane-is-here/) now:
* Feel free to migrate existing components to Glimmer Components.
* Write new ones exclusively in it.

Useful Resource : [Ember Octane vs Classic Cheat Sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Migrated touched components to Glimmer Components
- [x] Properly labeled
