### PR TITLE
The UTM input now follows the form guidelines

### DIFF
--- a/addon/components/utils/templated-input-group.hbs
+++ b/addon/components/utils/templated-input-group.hbs
@@ -1,13 +1,15 @@
 <div class="templated-input-group" ...attributes>
   <div class="fx-col fx-gap-px-3">
     <div class="fx-row fx-malign-space-between">
-      <div class="font-color-gray-500 font-size-md" data-control-name="templated-input-group-title">
-        {{#if @required}}
-          <span {{required-input}}>{{@title}}</span>
-        {{else}}
-          <span>{{@title}}</span>
-        {{/if}}
-      </div>
+      {{#if @required}}
+        <label {{required-input}} data-control-name="templated-input-group-title">
+          {{@title}}
+        </label>
+      {{else}}
+        <label data-control-name="templated-input-group-title">
+          {{@title}}
+        </label>
+      {{/if}}
       {{#unless @disabled}}
         <OSS::Link
           @icon="fa-plus"
@@ -44,7 +46,7 @@
         {{/each}}
       </div>
     </div>
-    <span class="font-color-gray-500 text-size-4" data-control-name="templated-input-group-subtitle">
+    <span class="font-color-gray-900 text-size-4" data-control-name="templated-input-group-subtitle">
       {{@subtitle}}
     </span>
   </div>

--- a/addon/components/utils/templated-input-group.hbs
+++ b/addon/components/utils/templated-input-group.hbs
@@ -56,6 +56,7 @@
     @onChange={{this.onInput}}
     @feedbackMessage={{this.feedbackMessage}}
     @disabled={{@disabled}}
+    {{on "focusout" this.validateInput}}
     {{on "keyup" this.triggerVariableInput}}
     {{did-insert this.registerInput}}
     data-control-name="templated-input-group-input-container"

--- a/addon/components/utils/templated-input-group.ts
+++ b/addon/components/utils/templated-input-group.ts
@@ -40,12 +40,12 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   get feedbackMessage(): FeedbackMessage | undefined {
     return (
       this.args.feedbackMessage ??
-      (!this.isInputValid
-        ? {
+      (this.isInputValid
+        ? undefined
+        : {
             type: 'error',
             value: this.intl.t('upf_utils.templated_input_group.error.invalid_merge_field')
-          }
-        : undefined)
+          })
     );
   }
 
@@ -64,11 +64,11 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   onInput(): void {
     const matches = [...this._inputValue.matchAll(VARIABLE_REGEX)];
 
-    if (matches.length > 1) {
-      const lastVariable = matches[matches.length - 1][0];
-      this.inputValue = this._inputValue.replace(VARIABLE_REGEX, '').replace(/\s+/g, ' ') + lastVariable;
-      this.inputElement?.focus();
-    }
+    if (matches.length <= 1) return;
+
+    const lastVariable = matches[matches.length - 1][0];
+    this.inputValue = this._inputValue.replace(VARIABLE_REGEX, '').replace(/\s+/g, ' ') + lastVariable;
+    this.inputElement?.focus();
   }
 
   @action
@@ -83,9 +83,9 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
       const cursorPosition = this.inputElement?.selectionStart ?? this._inputValue.length;
 
       this.inputValue =
-        variablePosition !== -1
-          ? this._inputValue.slice(0, variablePosition) + formattedVariable
-          : this._inputValue.slice(0, cursorPosition) + formattedVariable + this._inputValue.slice(cursorPosition);
+        variablePosition === -1
+          ? this._inputValue.slice(0, cursorPosition) + formattedVariable + this._inputValue.slice(cursorPosition)
+          : this._inputValue.slice(0, variablePosition) + formattedVariable;
     }
 
     this.inputElement?.focus();

--- a/addon/components/utils/templated-input-group.ts
+++ b/addon/components/utils/templated-input-group.ts
@@ -25,23 +25,18 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   @tracked displayTemplateVariables = false;
   @tracked displayLocalValidationError = false;
-  @tracked _inputValue = '';
+  @tracked _inputValue = this.args.value ?? '';
   @tracked inputElement?: HTMLInputElement | null;
   @tracked insertVariableLink?: HTMLElement | null;
-
-  constructor(owner: unknown, args: TemplatedInputGroupArgs) {
-    super(owner, args);
-    this._inputValue = args.value ?? '';
-  }
 
   set inputValue(value: string) {
     this._inputValue = value;
     this.displayLocalValidationError = false;
-    this.args.onChange(value, this.isInputValid);
+    this.args.onChange(value, this.isVariableFormat);
   }
 
   get inputValue(): string {
-    return this._inputValue;
+    return this.args.value;
   }
 
   get feedbackMessage(): FeedbackMessage | undefined {
@@ -50,7 +45,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   get localFeedbackMessage(): FeedbackMessage | undefined {
     const shouldDisplayLocalValidationError =
-      this.displayLocalValidationError && this.hasInputValue && !this.isInputValid;
+      this.displayLocalValidationError && this.hasInputValue && !this.isVariableFormat;
 
     return shouldDisplayLocalValidationError
       ? {
@@ -60,7 +55,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
       : undefined;
   }
 
-  get isInputValid(): boolean {
+  get isVariableFormat(): boolean {
     return (
       !this.matchedVariables ||
       (this.matchedVariables.length === 1 && this.args.variables.includes(this.matchedVariables[0].slice(2, -2)))
@@ -117,7 +112,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   @action
   validateInput(): void {
-    this.displayLocalValidationError = this.hasInputValue && !this.isInputValid;
+    this.displayLocalValidationError = this.hasInputValue && !this.isVariableFormat;
   }
 
   @action

--- a/addon/components/utils/templated-input-group.ts
+++ b/addon/components/utils/templated-input-group.ts
@@ -32,7 +32,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   set inputValue(value: string) {
     this._inputValue = value;
     this.displayLocalValidationError = false;
-    this.args.onChange(value, this.isVariableFormat);
+    this.args.onChange(value, this.isInputValid);
   }
 
   get inputValue(): string {
@@ -45,7 +45,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   get localFeedbackMessage(): FeedbackMessage | undefined {
     const shouldDisplayLocalValidationError =
-      this.displayLocalValidationError && this.hasInputValue && !this.isVariableFormat;
+      this.displayLocalValidationError && this.hasInputValue && !this.isInputValid;
 
     return shouldDisplayLocalValidationError
       ? {
@@ -55,14 +55,14 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
       : undefined;
   }
 
-  get isVariableFormat(): boolean {
+  get isInputValid(): boolean {
     return (
-      !this.matchedVariables ||
-      (this.matchedVariables.length === 1 && this.args.variables.includes(this.matchedVariables[0].slice(2, -2)))
+      !this.isVariableFormat ||
+      (this.isVariableFormat.length === 1 && this.args.variables.includes(this.isVariableFormat[0].slice(2, -2)))
     );
   }
 
-  get matchedVariables(): RegExpMatchArray | null {
+  get isVariableFormat(): RegExpMatchArray | null {
     return this.inputValue.match(VARIABLE_REGEX);
   }
 
@@ -86,7 +86,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
     e.stopPropagation();
     const formattedVariable = `{{${variable}}}`;
 
-    if (this.matchedVariables) {
+    if (this.isVariableFormat) {
       this.inputValue = this.inputValue.replace(VARIABLE_REGEX, formattedVariable);
     } else {
       const variablePosition = this.inputValue.indexOf('{');
@@ -112,7 +112,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   @action
   validateInput(): void {
-    this.displayLocalValidationError = this.hasInputValue && !this.isVariableFormat;
+    this.displayLocalValidationError = this.hasInputValue && !this.isInputValid;
   }
 
   @action

--- a/addon/components/utils/templated-input-group.ts
+++ b/addon/components/utils/templated-input-group.ts
@@ -29,14 +29,19 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   @tracked inputElement?: HTMLInputElement | null;
   @tracked insertVariableLink?: HTMLElement | null;
 
-  get inputValue(): string {
-    return this.args.value;
+  constructor(owner: unknown, args: TemplatedInputGroupArgs) {
+    super(owner, args);
+    this._inputValue = args.value ?? '';
   }
 
   set inputValue(value: string) {
     this._inputValue = value;
     this.displayLocalValidationError = false;
     this.args.onChange(value, this.isInputValid);
+  }
+
+  get inputValue(): string {
+    return this._inputValue;
   }
 
   get feedbackMessage(): FeedbackMessage | undefined {
@@ -47,37 +52,37 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
     const shouldDisplayLocalValidationError =
       this.displayLocalValidationError && this.hasInputValue && !this.isInputValid;
 
-    if (!shouldDisplayLocalValidationError) return undefined;
-
-    return {
-      type: 'error',
-      value: this.intl.t('upf_utils.templated_input_group.error.invalid_merge_field')
-    };
+    return shouldDisplayLocalValidationError
+      ? {
+          type: 'error',
+          value: this.intl.t('upf_utils.templated_input_group.error.invalid_merge_field')
+        }
+      : undefined;
   }
 
   get isInputValid(): boolean {
     return (
-      !this.variableMatches ||
-      (this.variableMatches.length === 1 && this.args.variables.includes(this.variableMatches[0].slice(2, -2)))
+      !this.matchedVariables ||
+      (this.matchedVariables.length === 1 && this.args.variables.includes(this.matchedVariables[0].slice(2, -2)))
     );
   }
 
-  get variableMatches(): RegExpMatchArray | null {
-    return this._inputValue.match(VARIABLE_REGEX);
+  get matchedVariables(): RegExpMatchArray | null {
+    return this.inputValue.match(VARIABLE_REGEX);
   }
 
   get hasInputValue(): boolean {
-    return this._inputValue.trim().length > 0;
+    return this.inputValue.trim().length > 0;
   }
 
   @action
   onInput(): void {
-    const matches = [...this._inputValue.matchAll(VARIABLE_REGEX)];
+    const matches = [...this.inputValue.matchAll(VARIABLE_REGEX)];
 
     if (matches.length <= 1) return;
 
     const lastVariable = matches[matches.length - 1][0];
-    this.inputValue = this._inputValue.replace(VARIABLE_REGEX, '').replace(/\s+/g, ' ') + lastVariable;
+    this.inputValue = this.inputValue.replace(VARIABLE_REGEX, '').replace(/\s+/g, ' ') + lastVariable;
     this.inputElement?.focus();
   }
 
@@ -86,16 +91,16 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
     e.stopPropagation();
     const formattedVariable = `{{${variable}}}`;
 
-    if (this.variableMatches) {
-      this.inputValue = this._inputValue.replace(VARIABLE_REGEX, formattedVariable);
+    if (this.matchedVariables) {
+      this.inputValue = this.inputValue.replace(VARIABLE_REGEX, formattedVariable);
     } else {
-      const variablePosition = this._inputValue.indexOf('{');
-      const cursorPosition = this.inputElement?.selectionStart ?? this._inputValue.length;
+      const variablePosition = this.inputValue.indexOf('{');
+      const cursorPosition = this.inputElement?.selectionStart ?? this.inputValue.length;
 
       this.inputValue =
         variablePosition === -1
-          ? this._inputValue.slice(0, cursorPosition) + formattedVariable + this._inputValue.slice(cursorPosition)
-          : this._inputValue.slice(0, variablePosition) + formattedVariable;
+          ? this.inputValue.slice(0, cursorPosition) + formattedVariable + this.inputValue.slice(cursorPosition)
+          : this.inputValue.slice(0, variablePosition) + formattedVariable;
     }
 
     this.inputElement?.focus();
@@ -104,8 +109,8 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   @action
   triggerVariableInput(): void {
-    const lastOpenIndex = this._inputValue.lastIndexOf('{{');
-    const lastCloseIndex = this._inputValue.lastIndexOf('}}');
+    const lastOpenIndex = this.inputValue.lastIndexOf('{{');
+    const lastCloseIndex = this.inputValue.lastIndexOf('}}');
 
     this.displayTemplateVariables = lastOpenIndex !== -1 && lastOpenIndex > lastCloseIndex;
   }
@@ -139,7 +144,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   @action
   registerInput(e: HTMLElement): void {
     this.inputElement = e.querySelector('input');
-    this._inputValue = this.inputElement?.value ?? this.args.value ?? '';
+    this._inputValue = this.inputElement?.value ?? this.inputValue;
   }
 
   @action

--- a/addon/components/utils/templated-input-group.ts
+++ b/addon/components/utils/templated-input-group.ts
@@ -24,6 +24,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   @service declare intl: IntlService;
 
   @tracked displayTemplateVariables = false;
+  @tracked displayLocalValidationError = false;
   @tracked _inputValue = '';
   @tracked inputElement?: HTMLInputElement | null;
   @tracked insertVariableLink?: HTMLElement | null;
@@ -34,19 +35,24 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   set inputValue(value: string) {
     this._inputValue = value;
+    this.displayLocalValidationError = false;
     this.args.onChange(value, this.isInputValid);
   }
 
   get feedbackMessage(): FeedbackMessage | undefined {
-    return (
-      this.args.feedbackMessage ??
-      (this.isInputValid
-        ? undefined
-        : {
-            type: 'error',
-            value: this.intl.t('upf_utils.templated_input_group.error.invalid_merge_field')
-          })
-    );
+    return this.args.feedbackMessage ?? this.localFeedbackMessage;
+  }
+
+  get localFeedbackMessage(): FeedbackMessage | undefined {
+    const shouldDisplayLocalValidationError =
+      this.displayLocalValidationError && this.hasInputValue && !this.isInputValid;
+
+    if (!shouldDisplayLocalValidationError) return undefined;
+
+    return {
+      type: 'error',
+      value: this.intl.t('upf_utils.templated_input_group.error.invalid_merge_field')
+    };
   }
 
   get isInputValid(): boolean {
@@ -58,6 +64,10 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
 
   get variableMatches(): RegExpMatchArray | null {
     return this._inputValue.match(VARIABLE_REGEX);
+  }
+
+  get hasInputValue(): boolean {
+    return this._inputValue.trim().length > 0;
   }
 
   @action
@@ -101,6 +111,11 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   }
 
   @action
+  validateInput(): void {
+    this.displayLocalValidationError = this.hasInputValue && !this.isInputValid;
+  }
+
+  @action
   toggleTemplateVariables(e: MouseEvent): void {
     e.stopPropagation();
     e.preventDefault();
@@ -124,6 +139,7 @@ export default class UtilsTemplatedInputGroup extends Component<TemplatedInputGr
   @action
   registerInput(e: HTMLElement): void {
     this.inputElement = e.querySelector('input');
+    this._inputValue = this.inputElement?.value ?? this.args.value ?? '';
   }
 
   @action

--- a/addon/components/utils/utm-link-builder.hbs
+++ b/addon/components/utils/utm-link-builder.hbs
@@ -17,6 +17,8 @@
           @value={{this.utmSource}}
           @placeholder={{t "utms.fields.source_placeholder"}}
           @required={{true}}
+          @feedbackMessage={{this.validationErrors.utmSource}}
+          {{on "focusout" (fn this.validateField "utmSource")}}
           data-control-name="utm_source_input"
         />
         <Utils::TemplatedInputGroup
@@ -26,6 +28,8 @@
           @value={{this.utmMedium}}
           @placeholder={{t "utms.fields.medium_placeholder"}}
           @required={{true}}
+          @feedbackMessage={{this.validationErrors.utmMedium}}
+          {{on "focusout" (fn this.validateField "utmMedium")}}
           data-control-name="utm_medium_input"
         />
         <Utils::TemplatedInputGroup
@@ -35,6 +39,8 @@
           @value={{this.utmCampaign}}
           @placeholder={{t "utms.fields.campaign_placeholder"}}
           @required={{true}}
+          @feedbackMessage={{this.validationErrors.utmCampaign}}
+          {{on "focusout" (fn this.validateField "utmCampaign")}}
           data-control-name="utm_campaign_input"
         />
       {{else}}

--- a/addon/components/utils/utm-link-builder.hbs
+++ b/addon/components/utils/utm-link-builder.hbs
@@ -40,12 +40,7 @@
       {{else}}
         <div class="fx-col fx-gap-px-6">
           <div class="fx-row">
-            <span class="font-color-gray-500 font-size-md">
-              {{t "utms.fields.source"}}
-            </span>
-            <span class="font-color-error-500">
-              *
-            </span>
+            <label {{required-input}}> {{t "utms.fields.source"}} </label>
           </div>
           <OSS::InputContainer
             @value={{this.utmSource}}
@@ -59,12 +54,7 @@
 
         <div class="fx-col fx-gap-px-6">
           <div class="fx-row">
-            <span class="font-color-gray-500 font-size-md">
-              {{t "utms.fields.medium"}}
-            </span>
-            <span class="font-color-error-500">
-              *
-            </span>
+            <label {{required-input}}> {{t "utms.fields.medium"}} </label>
           </div>
           <OSS::InputContainer
             @value={{this.utmMedium}}
@@ -78,12 +68,7 @@
 
         <div class="fx-col fx-gap-px-6">
           <div class="fx-row">
-            <span class="font-color-gray-500 font-size-md">
-              {{t "utms.fields.campaign"}}
-            </span>
-            <span class="font-color-error-500">
-              *
-            </span>
+            <label {{required-input}}> {{t "utms.fields.campaign"}} </label>
           </div>
           <OSS::InputContainer
             @value={{this.utmCampaign}}
@@ -97,16 +82,17 @@
       {{/if}}
     </div>
     {{#if this.displayPreview}}
-      <hr />
+      <hr class="margin-bottom-px-12 margin-top-px-12" />
       <div class="fx-1 fx-col fx-gap-px-6">
-        <span class="font-size-md font-color-gray-500">{{t "utms.preview"}}</span>
+        <span class="font-size-md font-color-gray-900">{{t "utms.preview"}}</span>
         <p class="link-preview">
           <span class="font-color-primary-500">{{this.fieldUrl}}</span>
           <span>
             &quest;utm_source=<span class="font-color-primary-500">{{this.fieldSource}}</span>
           </span>
-          <span>&amp;utm_medium=<span class="font-color-primary-500">{{this.fieldMedium}}</span></span>
-          <span class="text-color-gray-500">
+          <span>&amp;utm_medium=<span class="font-color-primary-500">{{this.fieldMedium}}</span>
+          </span>
+          <span>
             &amp;utm_campaign=<span class="font-color-primary-500">{{this.fieldCampaign}}</span>
           </span>
         </p>

--- a/addon/components/utils/utm-link-builder.ts
+++ b/addon/components/utils/utm-link-builder.ts
@@ -14,6 +14,9 @@ export type UtmFields = {
   utm_campaign: string;
 };
 
+const UTM_FIELDS = ['utmSource', 'utmMedium', 'utmCampaign'] as const;
+type UtmField = (typeof UTM_FIELDS)[number];
+
 interface UtilsUtmLinkBuilderArgs {
   url: string;
   title?: string;
@@ -97,16 +100,11 @@ export default class UtilsUtmLinkBuilder extends Component<UtilsUtmLinkBuilderAr
   }
 
   @action
-  validateField(field: string): void {
-    if (isBlank(this[field as keyof this])) {
+  validateField(field: UtmField): void {
+    if (isBlank(this[field])) {
       this.validationErrors = {
         ...this.validationErrors,
-        ...{
-          [field]: {
-            type: 'error',
-            value: this.intl.t('utms.errors.blank_field')
-          }
-        }
+        ...this.blankValidationErrors
       };
       this.notifyChanges();
       return;
@@ -127,6 +125,18 @@ export default class UtilsUtmLinkBuilder extends Component<UtilsUtmLinkBuilderAr
 
   get previewUrl(): string {
     return `${this.fieldUrl}?utm_source=${this.fieldSource}&utm_medium=${this.fieldMedium}&utm_campaign=${this.fieldCampaign}`;
+  }
+
+  get blankValidationErrors(): Record<string, FeedbackMessage> {
+    return UTM_FIELDS.reduce<Record<string, FeedbackMessage>>((errors, utmField) => {
+      if (isBlank(this[utmField])) {
+        errors[utmField] = {
+          type: 'error',
+          value: this.intl.t('utms.errors.blank_field')
+        };
+      }
+      return errors;
+    }, {});
   }
 
   get fieldUrl(): string {

--- a/tests/integration/components/utils/templated-input-group-test.ts
+++ b/tests/integration/components/utils/templated-input-group-test.ts
@@ -51,7 +51,8 @@ module('Integration | Component | utils/templated-input-group', function (hooks)
       await render(
         hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} />`
       );
-      assert.dom('[data-control-name="templated-input-group-title"]').hasText('Title*');
+      assert.dom('[data-control-name="templated-input-group-title"]').hasText('Title');
+      assert.dom('[data-control-name="templated-input-group-title"]').hasText('*');
     });
 
     test('Subtitle is displayed', async function (assert) {

--- a/tests/integration/components/utils/templated-input-group-test.ts
+++ b/tests/integration/components/utils/templated-input-group-test.ts
@@ -51,8 +51,8 @@ module('Integration | Component | utils/templated-input-group', function (hooks)
       await render(
         hbs`<Utils::TemplatedInputGroup @title={{this.title}} @value={{this.value}} @variables={{this.variables}} @onChange={{this.onChange}} @required={{true}} />`
       );
-      assert.dom('[data-control-name="templated-input-group-title"]').hasText('Title');
-      assert.dom('[data-control-name="templated-input-group-title"]').hasText('*');
+      assert.dom('[data-control-name="templated-input-group-title"]').includesText('Title');
+      assert.dom('[data-control-name="templated-input-group-title"]').includesText('*');
     });
 
     test('Subtitle is displayed', async function (assert) {

--- a/tests/integration/components/utils/utm-link-builder-test.ts
+++ b/tests/integration/components/utils/utm-link-builder-test.ts
@@ -132,6 +132,19 @@ module('Integration | Component | utils/utm-link-builder', function (hooks) {
       .containsText('Insert variable');
   });
 
+  test('If variables are enabled and a space character is inputed, it is replaced with a + sign', async function (assert) {
+    this.variables = ['InstagramUsername', 'TiktokUsername'];
+
+    await render(hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} @variables={{this.variables}} />`);
+    await click('.upf-toggle');
+
+    await typeIn('[data-control-name="utm_source_input"] .upf-input', 'a a', {
+      delay: 0
+    });
+    await settled();
+    assert.dom('[data-control-name="utm_source_input"] .upf-input').hasValue('a+a');
+  });
+
   test('When link params are passed, UTM link builder is toggled and filled with values', async function (assert) {
     this.linkParams = {
       utm_source: 'source',

--- a/tests/integration/components/utils/utm-link-builder-test.ts
+++ b/tests/integration/components/utils/utm-link-builder-test.ts
@@ -113,6 +113,20 @@ module('Integration | Component | utils/utm-link-builder', function (hooks) {
     });
   });
 
+  test('When one blank UTM field is blurred, all blank required fields display an error', async function (assert) {
+    await render(hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} />`);
+    await click('.upf-toggle');
+    await focus('[data-control-name="utm_source_input"] input');
+    await blur('[data-control-name="utm_source_input"] input');
+
+    ['utm_source', 'utm_medium', 'utm_campaign'].forEach((field) => {
+      assert.dom(`[data-control-name="${field}_input"] + .font-color-error-500`).exists();
+      assert
+        .dom(`[data-control-name="${field}_input"] + .font-color-error-500`)
+        .hasText(this.intl.t('utms.errors.blank_field'));
+    });
+  });
+
   test('If variables are unavailable, templated input group component is not rendered', async function (assert) {
     this.variables = ['InstagramUsername', 'TiktokUsername'];
 
@@ -143,6 +157,19 @@ module('Integration | Component | utils/utm-link-builder', function (hooks) {
     });
     await settled();
     assert.dom('[data-control-name="utm_source_input"] .upf-input').hasValue('a+a');
+  });
+
+  test('When variables are enabled and one blank UTM field is blurred, all blank required fields display an error', async function (assert) {
+    this.variables = ['InstagramUsername', 'TiktokUsername'];
+
+    await render(hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} @variables={{this.variables}} />`);
+    await click('.upf-toggle');
+    await focus('[data-control-name="utm_source_input"] input');
+    await blur('[data-control-name="utm_source_input"] input');
+
+    ['utm_source', 'utm_medium', 'utm_campaign'].forEach((field) => {
+      assert.dom(`[data-control-name="${field}_input"]`).includesText(this.intl.t('utms.errors.blank_field'));
+    });
   });
 
   test('When link params are passed, UTM link builder is toggled and filled with values', async function (assert) {

--- a/tests/integration/components/utils/utm-link-builder-test.ts
+++ b/tests/integration/components/utils/utm-link-builder-test.ts
@@ -132,19 +132,6 @@ module('Integration | Component | utils/utm-link-builder', function (hooks) {
       .containsText('Insert variable');
   });
 
-  test('If variables are enabled and a space character is inputed, it is replaced with a + sign', async function (assert) {
-    this.variables = ['InstagramUsername', 'TiktokUsername'];
-
-    await render(hbs`<Utils::UtmLinkBuilder @onChange={{this.onChange}} @variables={{this.variables}} />`);
-    await click('.upf-toggle');
-
-    await typeIn('[data-control-name="utm_source_input"] .upf-input', 'a a', {
-      delay: 0
-    });
-    await settled();
-    assert.dom('[data-control-name="utm_source_input"] .upf-input').hasValue('a+a');
-  });
-
   test('When link params are passed, UTM link builder is toggled and filled with values', async function (assert) {
     this.linkParams = {
       utm_source: 'source',


### PR DESCRIPTION
### What does this PR do?

Refactor input groups by replacing spans with labels to follow the form guidelines.

Related to: [#DRA-4003](https://linear.app/upfluence/issue/DRA-4003)

### What are the observable changes?

The input now follows the form guidelines

Before:
<img width="589" height="661" alt="image" src="https://github.com/user-attachments/assets/550d4bf2-f68a-4ebf-acf0-3befde526b98" />


After:
<img width="597" height="686" alt="image" src="https://github.com/user-attachments/assets/13479a3a-ed4d-4f48-8909-e72bb671d26c" />

### 🧑‍💻 Developer Heads Up

N/A

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
